### PR TITLE
Remove time-related fields from `AbstractThermoParams`

### DIFF
--- a/src/TPM.jl
+++ b/src/TPM.jl
@@ -359,7 +359,8 @@ function run_TPM!(stpm::SingleTPM, ephem, savepath)
         ProgressMeter.next!(p; showvalues)
 
         nₜ == length(ephem.time) && break  # Stop to update the temperature at the final step
-        update_temperature!(stpm)
+        Δt = ephem.time[nₜ+1] - ephem.time[nₜ]
+        update_temperature!(stpm, Δt)
     end
 
     jldsave(savepath; stpm, ephem, surf_temps, forces, torques)
@@ -427,7 +428,8 @@ function run_TPM!(btpm::BinaryTPM, ephem, savepath)
         
         ## Update temperature distribution
         nₜ == length(ephem.time) && break  # Stop to update the temperature at the final step
-        update_temperature!(btpm)
+        Δt = ephem.time[nₜ+1] - ephem.time[nₜ]
+        update_temperature!(btpm, Δt)
     end
     
     jldsave(savepath; btpm, ephem, surf_temps, forces, torques)

--- a/src/heat_conduction.jl
+++ b/src/heat_conduction.jl
@@ -11,6 +11,7 @@ Calculate the temperature for the next time step based on 1D heat conduction equ
 
 # Arguments
 - `stpm` : Thermophysical model for a single asteroid
+- `Δt`   : Time step [sec]
 """
 function update_temperature!(stpm::SingleTPM, Δt)
     if stpm.SOLVER isa ForwardEulerSolver
@@ -32,7 +33,7 @@ Calculate the temperature for the next time step based on 1D heat conductivity e
 
 # Arguments
 - `btpm` : Thermophysical model for a binary asteroid
-- `nₜ`   : Index of the current time step
+- `Δt`   : Time step [sec]
 """
 function update_temperature!(btpm::BinaryTPM, Δt)
     update_temperature!(btpm.pri, Δt)

--- a/src/heat_conduction.jl
+++ b/src/heat_conduction.jl
@@ -5,20 +5,20 @@
 # ****************************************************************
 
 """
-    update_temperature!(stpm::SingleTPM)
+    update_temperature!(stpm::SingleTPM, Δt)
 
 Calculate the temperature for the next time step based on 1D heat conduction equation.
 
 # Arguments
 - `stpm` : Thermophysical model for a single asteroid
 """
-function update_temperature!(stpm::SingleTPM)
+function update_temperature!(stpm::SingleTPM, Δt)
     if stpm.SOLVER isa ForwardEulerSolver
-        forward_euler!(stpm)
+        forward_euler!(stpm, Δt)
     elseif stpm.SOLVER isa BackwardEulerSolver
-        backward_euler!(stpm)
+        backward_euler!(stpm, Δt)
     elseif stpm.SOLVER isa CrankNicolsonSolver
-        crank_nicolson!(stpm)
+        crank_nicolson!(stpm, Δt)
     else
         error("The solver is not implemented.")
     end
@@ -26,7 +26,7 @@ end
 
 
 """
-    update_temperature!(btpm::BinaryTPM)
+    update_temperature!(btpm::BinaryTPM, Δt)
 
 Calculate the temperature for the next time step based on 1D heat conductivity equation.
 
@@ -34,9 +34,9 @@ Calculate the temperature for the next time step based on 1D heat conductivity e
 - `btpm` : Thermophysical model for a binary asteroid
 - `nₜ`   : Index of the current time step
 """
-function update_temperature!(btpm::BinaryTPM)
-    update_temperature!(btpm.pri)
-    update_temperature!(btpm.sec)
+function update_temperature!(btpm::BinaryTPM, Δt)
+    update_temperature!(btpm.pri, Δt)
+    update_temperature!(btpm.sec, Δt)
 end
 
 # ****************************************************************
@@ -45,20 +45,30 @@ end
 
 
 """
-    forward_euler!(stpm::SingleTPM, nₜ::Integer)
+    forward_euler!(stpm::SingleTPM, Δt)
 
 Predict the temperature at the next time step by the forward Euler method.
 - Explicit in time
 - First order in time
 In this function, the heat conduction equation is non-dimensionalized in time and length.
+
+# Arguments
+- `stpm` : Thermophysical model for a single asteroid
+- `Δt`   : Time step [sec]
 """
-function forward_euler!(stpm::SingleTPM)
+function forward_euler!(stpm::SingleTPM, Δt)
     T = stpm.temperature
     Nz = size(T, 1)
     Ns = size(T, 2)
 
     for nₛ in 1:Ns
-        λ = (stpm.thermo_params.λ isa Real ? stpm.thermo_params.λ : stpm.thermo_params.λ[nₛ])
+        P  = stpm.thermo_params.P
+        Δz = stpm.thermo_params.Δz
+        l  = (stpm.thermo_params.l isa Real ? stpm.thermo_params.l : stpm.thermo_params.l[nₛ])
+
+        λ = (Δt/P) / (Δz/l)^2 / 4π
+        λ ≥ 0.5 && error("The forward Euler method is unstable because λ = $λ. This should be less than 0.5.")
+
         for nz in 2:(Nz-1)
             stpm.SOLVER.T[nz] = (1-2λ)*T[nz, nₛ] + λ*(T[nz+1, nₛ] + T[nz-1, nₛ])  # Predict temperature at next time step
         end
@@ -73,7 +83,7 @@ end
 
 
 """
-    backward_euler!(stpm::SingleTPM)
+    backward_euler!(stpm::SingleTPM, Δt)
 
 Predict the temperature at the next time step by the backward Euler method.
 - Implicit in time (Unconditionally stable in the heat conduction equation)
@@ -81,7 +91,7 @@ Predict the temperature at the next time step by the backward Euler method.
 - Second order in space
 In this function, the heat conduction equation is non-dimensionalized in time and length.
 """
-function backward_euler!(stpm::SingleTPM)
+function backward_euler!(stpm::SingleTPM, Δt)
     # T = stpm.temperature
     # Nz = size(T, 1)
     # Ns = size(T, 2)
@@ -114,7 +124,7 @@ end
 
 
 """
-    crank_nicolson!(stpm::SingleTPM)
+    crank_nicolson!(stpm::SingleTPM, Δt)
 
 Predict the temperature at the next time step by the Crank-Nicolson method.
 - Implicit in time (Unconditionally stable in the heat conduction equation)
@@ -122,7 +132,7 @@ Predict the temperature at the next time step by the Crank-Nicolson method.
 - Second order in space
 In this function, the heat conduction equation is non-dimensionalized in time and length.
 """
-function crank_nicolson!(stpm::SingleTPM)
+function crank_nicolson!(stpm::SingleTPM, Δt)
     # T = stpm.temperature
     # Nz = size(T, 1)
     # Ns = size(T, 2)

--- a/src/thermo_params.jl
+++ b/src/thermo_params.jl
@@ -46,15 +46,9 @@ abstract type AbstractThermoParams end
 - `P`     : Cycle of thermal cycle (rotation period) [sec]
 - `l`     : Thermal skin depth [m]
 - `Γ`     : Thermal inertia [J ⋅ m⁻² ⋅ K⁻¹ ⋅ s⁻⁰⁵ (tiu)]
-- `λ`     : Non-dimensional coefficient for heat diffusion equation
 - `A_B`   : Bond albedo
 - `A_TH`  : Albedo at thermal radiation wavelength
 - `ε`     : Emissivity
-
-- `t_begin` : Start time of the thermophysical simulation [sec]
-- `t_end`   : End time of the thermophysical simulation [sec]
-- `Δt`      : Timestep [sec]
-- `Nt`      : Number of timesteps
 
 - `z_max` : Depth of the bottom of a heat conduction equation [m]
 - `Δz`    : Depth step width [m]
@@ -64,15 +58,9 @@ struct NonUniformThermoParams <: AbstractThermoParams
     P       ::Float64          # Common for all faces
     l       ::Vector{Float64}
     Γ       ::Vector{Float64}
-    λ       ::Vector{Float64}
     A_B     ::Vector{Float64}
     A_TH    ::Vector{Float64}
     ε       ::Vector{Float64}
-
-    t_begin ::Float64          # Common for all faces
-    t_end   ::Float64          # Common for all faces
-    Δt      ::Float64          # Common for all faces
-    Nt      ::Int              # Common for all faces
 
     z_max   ::Float64          # Common for all faces
     Δz      ::Float64          # Common for all faces
@@ -86,15 +74,9 @@ end
 - `P`     : Thermal cycle (rotation period) [sec]
 - `l`     : Thermal skin depth [m]
 - `Γ`     : Thermal inertia [J ⋅ m⁻² ⋅ K⁻¹ ⋅ s⁻⁰⁵ (tiu)]
-- `λ`     : Non-dimensional coefficient for heat diffusion equation
 - `A_B`   : Bond albedo
 - `A_TH`  : Albedo at thermal radiation wavelength
 - `ε`     : Emissivity
-
-- `t_begin` : Start time of the thermophysical simulation [sec]
-- `t_end`   : End time of the thermophysical simulation [sec]
-- `Δt`      : Timestep [sec]
-- `Nt`      : Number of timesteps
 
 - `z_max` : Depth of the bottom of a heat conduction equation [m]
 - `Δz`    : Depth step width [m]
@@ -104,15 +86,9 @@ struct UniformThermoParams <: AbstractThermoParams
     P       ::Float64
     l       ::Float64
     Γ       ::Float64
-    λ       ::Float64
     A_B     ::Float64
     A_TH    ::Float64
     ε       ::Float64
-
-    t_begin ::Float64
-    t_end   ::Float64
-    Δt      ::Float64
-    Nt      ::Int
 
     z_max   ::Float64
     Δz      ::Float64
@@ -123,15 +99,10 @@ end
 """
     thermoparams(; A_B, A_TH, k, ρ, Cp, ε, t_begin, t_end, Nt, z_max, Nz, P)
 """
-function thermoparams(; P, l, Γ, A_B, A_TH, ε, t_begin, t_end, Nt, z_max, Nz)
+function thermoparams(; P, l, Γ, A_B, A_TH, ε, z_max, Nz)
 
-    Δt = (t_end - t_begin) / (Nt - 1)
     Δz = z_max / (Nz - 1)
-
-    λ = @. (Δt/P) / (Δz/l)^2 / 4π
-    maximum(λ) > 0.5 && error("λ should be smaller than 0.5 for convergence of the forward Euler method.")
-
-    LENGTH = maximum(length, [A_B, A_TH, ε, l, Γ, λ])
+    LENGTH = maximum(length, [A_B, A_TH, ε, l, Γ])
 
     if LENGTH > 1
         A_B   isa Real && (A_B  = fill(A_B,  LENGTH))
@@ -139,11 +110,10 @@ function thermoparams(; P, l, Γ, A_B, A_TH, ε, t_begin, t_end, Nt, z_max, Nz)
         ε     isa Real && (ε    = fill(ε,    LENGTH))
         l     isa Real && (l    = fill(l,    LENGTH))
         Γ     isa Real && (Γ    = fill(Γ,    LENGTH))
-        λ     isa Real && (λ    = fill(λ,    LENGTH))
         
-        NonUniformThermoParams(P, l, Γ, λ, A_B, A_TH, ε, t_begin, t_end, Δt, Nt, z_max, Δz, Nz)
+        NonUniformThermoParams(P, l, Γ, A_B, A_TH, ε, z_max, Δz, Nz)
     else
-        UniformThermoParams(P, l, Γ, λ, A_B, A_TH, ε, t_begin, t_end, Δt, Nt, z_max, Δz, Nz)
+        UniformThermoParams(P, l, Γ, A_B, A_TH, ε, z_max, Δz, Nz)
     end
 end
 
@@ -158,21 +128,10 @@ function Base.show(io::IO, params::UniformThermoParams)
     msg *= "          = $(SPICE.convrt(params.P, "seconds", "hours")) [h]\n"
     msg *= "  l       = $(params.l) [m]\n"
     msg *= "  Γ       = $(params.Γ) [tiu]\n"
-    msg *= "  λ       = $(params.λ)\n"
     msg *= "  A_B     = $(params.A_B)\n"
     msg *= "  A_TH    = $(params.A_TH)\n"
     msg *= "  ε       = $(params.ε)\n"
-    
-    msg *= "-----------------------------------\n"
-
-    msg *= "  t_begin = $(params.t_begin) [sec]\n"
-    msg *= "          = $(params.t_begin / params.P) [P]\n"
-    msg *= "  t_end   = $(params.t_end) [sec]\n"
-    msg *= "          = $(params.t_end / params.P) [P]\n"
-    msg *= "  Δt      = $(params.Δt) [sec]\n"
-    msg *= "          = $(params.Δt / params.P) [P]\n"
-    msg *= "  Nt      = $(params.Nt)\n"
-
+  
     msg *= "-----------------------------------\n"
 
     msg *= "  z_max   = $(params.z_max) [m]\n"

--- a/test/TPM_Didymos.jl
+++ b/test/TPM_Didymos.jl
@@ -107,9 +107,6 @@
         A_B     = 0.059,  # Bolometric Bond albedo
         A_TH    = 0.0,
         ε       = 0.9,
-        t_begin = et_range[begin],
-        t_end   = et_range[end],
-        Nt      = length(et_range),
         z_max   = 0.6,
         Nz      = 41,
     )

--- a/test/TPM_Ryugu.jl
+++ b/test/TPM_Ryugu.jl
@@ -85,9 +85,6 @@
         A_B     = 0.04,  # Bolometric Bond albedo
         A_TH    = 0.0,
         ε       = 1.0,
-        t_begin = et_range[begin],
-        t_end   = et_range[end],
-        Nt      = length(et_range),
         z_max   = 0.6,
         Nz      = 41,
     )

--- a/test/heat_conduction_1D.jl
+++ b/test/heat_conduction_1D.jl
@@ -37,9 +37,6 @@
         A_B     = 0.0,
         A_TH    = 0.0,
         ε       = 1.0,
-        t_begin = et_range[begin],
-        t_end   = et_range[end],
-        Nt      = length(et_range),
         z_max   = 1.0,
         Nz      = 101,
     )

--- a/test/heat_conduction_1D.jl
+++ b/test/heat_conduction_1D.jl
@@ -65,10 +65,11 @@
     ##= Run TPM =##
     for nₜ in eachindex(ephem.time)
         nₜ == length(et_range) && break  # Stop to update the temperature at the final step
+        Δt = ephem.time[nₜ+1] - ephem.time[nₜ]
         
-        AsteroidThermoPhysicalModels.forward_euler!(stpm_FE)
-        AsteroidThermoPhysicalModels.backward_euler!(stpm_BE)
-        AsteroidThermoPhysicalModels.crank_nicolson!(stpm_CN)
+        AsteroidThermoPhysicalModels.forward_euler!(stpm_FE, Δt)
+        AsteroidThermoPhysicalModels.backward_euler!(stpm_BE, Δt)
+        AsteroidThermoPhysicalModels.crank_nicolson!(stpm_CN, Δt)
     end
 
     ##= Save data =##

--- a/test/non-uniform_thermoparams.jl
+++ b/test/non-uniform_thermoparams.jl
@@ -100,9 +100,6 @@
         A_B     = [r[3] > 0 ? 0.04 : 0.1 for r in shape.face_centers],
         A_TH    = 0.0,
         ε       = [r[3] > 0 ? 1.0 : 0.9  for r in shape.face_centers],
-        t_begin = et_range[begin],
-        t_end   = et_range[end],
-        Nt      = length(et_range),
         z_max   = 0.6,
         Nz      = 41,
     )


### PR DESCRIPTION
Remove the time-related fields from `UniformThermoParams` and `NonUniformThermoParams`: `t_begin`, `t_end`, `Δt`, `Nt`, and `λ`. These values can be obtained from a given ephemeris time at each time step.