### PR TITLE
Change the order of functions for energy flux

### DIFF
--- a/src/TPM.jl
+++ b/src/TPM.jl
@@ -641,10 +641,9 @@ function run_TPM!(btpm::BinaryTPM, ephem, time_begin::Real, time_end::Real, face
 
         ## Update enegey flux
         update_flux_sun!(btpm, r☉₁, r☉₂)
+        mutual_shadowing!(btpm, r☉₁, rₛ, R₂₁)  # Mutual-shadowing (eclipse)
         update_flux_scat_single!(btpm)
         update_flux_rad_single!(btpm)
-
-        mutual_shadowing!(btpm, r☉₁, rₛ, R₂₁)  # Mutual-shadowing (eclipse)
         mutual_heating!(btpm, rₛ, R₂₁)         # Mutual-heating
 
         update_thermal_force!(btpm)


### PR DESCRIPTION
Change the order of the functions to calculate the energy flux. `mutual_shadowing!`, which changes the solar flux on a binary asteroid, should be placed before calculating the scattering flux.