### PR TITLE
Rename abstract/concrete types

### DIFF
--- a/src/AsteroidThermoPhysicalModels.jl
+++ b/src/AsteroidThermoPhysicalModels.jl
@@ -28,19 +28,22 @@ export ShapeModel, load_shape_obj
 
 include("thermo_params.jl")
 include("TPM.jl")
+
+# Alias for the types defined in `TPM.jl`
+# `TPM` is a abbreviation for a "thermophysical model".
+const AbstractAsteroidTPM = AbstractAsteroidThermoPhysicalModel
+const SingleAsteroidTPM = SingleAsteroidThermoPhysicalModel
+const BinaryAsteroidTPM = BinaryAsteroidThermoPhysicalModel
+const SingleAsteroidTPMResult = SingleAsteroidThermoPhysicalModelResult
+const BinaryAsteroidTPMResult = BinaryAsteroidThermoPhysicalModelResult
+export AbstractAsteroidThermoPhysicalModel, SingleAsteroidThermoPhysicalModel, BinaryAsteroidThermoPhysicalModel
+export AbstractAsteroidTPM, SingleAsteroidTPM, BinaryAsteroidTPM
+
 include("heat_conduction.jl")
 include("energy_flux.jl")
 include("non_grav.jl")
 include("thermal_radiation.jl")
 export thermal_skin_depth, thermal_inertia, init_temperature!, run_TPM!
-
-# Alias for the abstract type and struct defined in `TPM.jl`
-# `TPM` is a abbreviation for a "thermophysical model".
-const AbstractAsteroidTPM = AbstractAsteroidThermoPhysicalModel
-const SingleAsteroidTPM = SingleAsteroidThermoPhysicalModel
-const BinaryAsteroidTPM = BinaryAsteroidThermoPhysicalModel
-export AbstractAsteroidThermoPhysicalModel, SingleAsteroidThermoPhysicalModel, BinaryAsteroidThermoPhysicalModel
-export AbstractAsteroidTPM, SingleAsteroidTPM, BinaryAsteroidTPM
 
 include("roughness.jl")
 

--- a/src/AsteroidThermoPhysicalModels.jl
+++ b/src/AsteroidThermoPhysicalModels.jl
@@ -34,6 +34,14 @@ include("non_grav.jl")
 include("thermal_radiation.jl")
 export thermal_skin_depth, thermal_inertia, init_temperature!, run_TPM!
 
+# Alias for the abstract type and struct defined in `TPM.jl`
+# `TPM` is a abbreviation for a "thermophysical model".
+const AbstractAsteroidTPM = AbstractAsteroidThermoPhysicalModel
+const SingleAsteroidTPM = SingleAsteroidThermoPhysicalModel
+const BinaryAsteroidTPM = BinaryAsteroidThermoPhysicalModel
+export AbstractAsteroidThermoPhysicalModel, SingleAsteroidThermoPhysicalModel, BinaryAsteroidThermoPhysicalModel
+export AbstractAsteroidTPM, SingleAsteroidTPM, BinaryAsteroidTPM
+
 include("roughness.jl")
 
 end # module AsteroidThermoPhysicalModels

--- a/src/TPM.jl
+++ b/src/TPM.jl
@@ -106,11 +106,9 @@ The `AbstractAsteroidTPM` type is an alias for `AbstractAsteroidThermoPhysicalMo
 """
 abstract type AbstractAsteroidThermoPhysicalModel end
 
-const AbstractAsteroidTPM = AbstractAsteroidThermoPhysicalModel  # Alias for the abstract type. `TPM` is a abbreviation for a "thermophysical model".
-
 
 """
-    struct SingleAsteroidThermoPhysicalModel <: AbstractAsteroidTPM
+    struct SingleAsteroidThermoPhysicalModel <: AbstractAsteroidThermoPhysicalModel
 
 # Fields
 - `shape`          : Shape model
@@ -135,7 +133,7 @@ const AbstractAsteroidTPM = AbstractAsteroidThermoPhysicalModel  # Alias for the
 # TODO:
 - roughness_maps   ::ShapeModel[]
 """
-struct SingleAsteroidThermoPhysicalModel{P<:AbstractThermoParams, S<:HeatConductionSolver, BU<:BoundaryCondition, BL<:BoundaryCondition} <: AbstractAsteroidTPM
+struct SingleAsteroidThermoPhysicalModel{P<:AbstractThermoParams, S<:HeatConductionSolver, BU<:BoundaryCondition, BL<:BoundaryCondition} <: AbstractAsteroidThermoPhysicalModel
     shape          ::ShapeModel
     thermo_params  ::P
 
@@ -152,9 +150,6 @@ struct SingleAsteroidThermoPhysicalModel{P<:AbstractThermoParams, S<:HeatConduct
     BC_UPPER       ::BU
     BC_LOWER       ::BL
 end
-
-
-const SingleAsteroidTPM = SingleAsteroidThermoPhysicalModel  # Alias for the struct. `TPM` is a abbreviation for a "thermophysical model".
 
 
 """
@@ -190,7 +185,7 @@ end
 
 
 """
-    struct BinaryAsteroidThermoPhysicalModel{M1, M2} <: AbstractAsteroidTPM
+    struct BinaryAsteroidThermoPhysicalModel{M1, M2} <: AbstractAsteroidThermoPhysicalModel
 
 # Fields
 - `pri`              : TPM for the primary
@@ -198,16 +193,13 @@ end
 - `MUTUAL_SHADOWING` : Flag to consider mutual shadowing
 - `MUTUAL_HEATING`   : Flag to consider mutual heating
 """
-struct BinaryAsteroidThermoPhysicalModel{M1, M2} <: AbstractAsteroidTPM
+struct BinaryAsteroidThermoPhysicalModel{M1, M2} <: AbstractAsteroidThermoPhysicalModel
     pri              ::M1
     sec              ::M2
 
     MUTUAL_SHADOWING ::Bool
     MUTUAL_HEATING   ::Bool
 end
-
-
-const BinaryAsteroidTPM = BinaryAsteroidThermoPhysicalModel
 
 
 """

--- a/src/TPM.jl
+++ b/src/TPM.jl
@@ -110,7 +110,7 @@ const AbstractAsteroidTPM = AbstractAsteroidThermoPhysicalModel  # Alias for the
 
 
 """
-    struct SingleTPM <: AbstractAsteroidTPM
+    struct SingleAsteroidThermoPhysicalModel <: AbstractAsteroidTPM
 
 # Fields
 - `shape`          : Shape model
@@ -135,7 +135,7 @@ const AbstractAsteroidTPM = AbstractAsteroidThermoPhysicalModel  # Alias for the
 # TODO:
 - roughness_maps   ::ShapeModel[]
 """
-struct SingleTPM{P<:AbstractThermoParams, S<:HeatConductionSolver, BU<:BoundaryCondition, BL<:BoundaryCondition} <: AbstractAsteroidTPM
+struct SingleAsteroidThermoPhysicalModel{P<:AbstractThermoParams, S<:HeatConductionSolver, BU<:BoundaryCondition, BL<:BoundaryCondition} <: AbstractAsteroidTPM
     shape          ::ShapeModel
     thermo_params  ::P
 
@@ -155,9 +155,9 @@ end
 
 
 """
-    SingleTPM(shape, thermo_params; SELF_SHADOWING=true, SELF_HEATING=true) -> stpm
+    SingleAsteroidThermoPhysicalModel(shape, thermo_params; SELF_SHADOWING=true, SELF_HEATING=true) -> stpm
 
-Construct a thermophysical model for a single asteroid (`SingleTPM`).
+Construct a thermophysical model for a single asteroid (`SingleAsteroidThermoPhysicalModel`).
 
 # Arguments
 - `shape`          : Shape model
@@ -170,7 +170,7 @@ Construct a thermophysical model for a single asteroid (`SingleTPM`).
 - `BC_UPPER`       : Boundary condition at the upper boundary
 - `BC_LOWER`       : Boundary condition at the lower boundary
 """
-function SingleTPM(shape, thermo_params; SELF_SHADOWING, SELF_HEATING, SOLVER, BC_UPPER, BC_LOWER)
+function SingleAsteroidThermoPhysicalModel(shape, thermo_params; SELF_SHADOWING, SELF_HEATING, SOLVER, BC_UPPER, BC_LOWER)
 
     n_depth = thermo_params.n_depth
     n_face = length(shape.faces)
@@ -182,12 +182,12 @@ function SingleTPM(shape, thermo_params; SELF_SHADOWING, SELF_HEATING, SOLVER, B
     force  = zero(MVector{3, Float64})
     torque = zero(MVector{3, Float64})
 
-    SingleTPM(shape, thermo_params, flux, temperature, face_forces, force, torque, SELF_SHADOWING, SELF_HEATING, SOLVER, BC_UPPER, BC_LOWER)
+    SingleAsteroidThermoPhysicalModel(shape, thermo_params, flux, temperature, face_forces, force, torque, SELF_SHADOWING, SELF_HEATING, SOLVER, BC_UPPER, BC_LOWER)
 end
 
 
 """
-    struct BinaryTPM{M1, M2} <: AbstractAsteroidTPM
+    struct BinaryAsteroidThermoPhysicalModel{M1, M2} <: AbstractAsteroidTPM
 
 # Fields
 - `pri`              : TPM for the primary
@@ -195,7 +195,7 @@ end
 - `MUTUAL_SHADOWING` : Flag to consider mutual shadowing
 - `MUTUAL_HEATING`   : Flag to consider mutual heating
 """
-struct BinaryTPM{M1, M2} <: AbstractAsteroidTPM
+struct BinaryAsteroidThermoPhysicalModel{M1, M2} <: AbstractAsteroidTPM
     pri              ::M1
     sec              ::M2
 
@@ -205,19 +205,19 @@ end
 
 
 """
-    BinaryTPM(pri, sec; MUTUAL_SHADOWING=true, MUTUAL_HEATING=true) -> btpm
+    BinaryAsteroidThermoPhysicalModel(pri, sec; MUTUAL_SHADOWING=true, MUTUAL_HEATING=true) -> btpm
 
-Construct a thermophysical model for a binary asteroid (`BinaryTPM`).
+Construct a thermophysical model for a binary asteroid (`BinaryAsteroidThermoPhysicalModel`).
 """
-function BinaryTPM(pri, sec; MUTUAL_SHADOWING, MUTUAL_HEATING)
-    BinaryTPM(pri, sec, MUTUAL_SHADOWING, MUTUAL_HEATING)
+function BinaryAsteroidThermoPhysicalModel(pri, sec; MUTUAL_SHADOWING, MUTUAL_HEATING)
+    BinaryAsteroidThermoPhysicalModel(pri, sec, MUTUAL_SHADOWING, MUTUAL_HEATING)
 end
 
 
 """
 Return surface temperature of a single asteroid corrsponding to each face.
 """
-surface_temperature(stpm::SingleTPM) = stpm.temperature[begin, :]
+surface_temperature(stpm::SingleAsteroidThermoPhysicalModel) = stpm.temperature[begin, :]
 
 
 # ****************************************************************
@@ -225,9 +225,9 @@ surface_temperature(stpm::SingleTPM) = stpm.temperature[begin, :]
 # ****************************************************************
 
 """
-    struct SingleTPMResult
+    struct SingleAsteroidThermoPhysicalModelResult
 
-Output data format for `SingleTPM` 
+Output data format for `SingleAsteroidThermoPhysicalModel` 
 
 # Fields
 ## Saved at all time steps
@@ -251,7 +251,7 @@ Output data format for `SingleTPM`
     - `n_face` : Number of faces
     - `n_time` : Number of time steps to save surface temperature
 """
-struct SingleTPMResult
+struct SingleAsteroidThermoPhysicalModelResult
     times  ::Vector{Float64}
     E_in   ::Vector{Float64}
     E_out  ::Vector{Float64}
@@ -268,7 +268,7 @@ end
 
 
 """
-Outer constructor of `SingleTPMResult`
+Outer constructor of `SingleAsteroidThermoPhysicalModelResult`
 
 # Arguments
 - `stpm`          : Thermophysical model for a single asteroid
@@ -276,7 +276,7 @@ Outer constructor of `SingleTPMResult`
 - `times_to_save` : Timesteps to save temperature
 - `face_ID`       : Face indices to save subsurface temperature
 """
-function SingleTPMResult(stpm::SingleTPM, ephem, times_to_save::Vector{Float64}, face_ID::Vector{Int})
+function SingleAsteroidThermoPhysicalModelResult(stpm::SingleAsteroidThermoPhysicalModel, ephem, times_to_save::Vector{Float64}, face_ID::Vector{Int})
     n_step = length(ephem.time)             # Number of time steps
     n_step_to_save = length(times_to_save)  # Number of time steps to save temperature
     n_face = length(stpm.shape.faces)       # Number of faces of the shape model
@@ -294,7 +294,7 @@ function SingleTPMResult(stpm::SingleTPM, ephem, times_to_save::Vector{Float64},
     )
     face_forces = zeros(SVector{3, Float64}, n_face, n_step_to_save)
 
-    return SingleTPMResult(
+    return SingleAsteroidThermoPhysicalModelResult(
         ephem.time,
         E_in,
         E_out,
@@ -311,22 +311,22 @@ end
 
 
 """
-    struct BinaryTPMResult
+    struct BinaryAsteroidThermoPhysicalModelResult
 
-Output data format for `BinaryTPM`
+Output data format for `BinaryAsteroidThermoPhysicalModel`
 
 # Fields
 - `pri` : TPM result for the primary
 - `sec` : TPM result for the secondary
 """
-struct BinaryTPMResult
-    pri::SingleTPMResult
-    sec::SingleTPMResult
+struct BinaryAsteroidThermoPhysicalModelResult
+    pri::SingleAsteroidThermoPhysicalModelResult
+    sec::SingleAsteroidThermoPhysicalModelResult
 end
 
 
 """
-Outer constructor of `BinaryTPMResult`
+Outer constructor of `BinaryAsteroidThermoPhysicalModelResult`
 
 # Arguments
 - `btpm`          : Thermophysical model for a binary asteroid
@@ -335,25 +335,25 @@ Outer constructor of `BinaryTPMResult`
 - `face_ID_pri`   : Face indices to save subsurface temperature of the primary
 - `face_ID_sec`   : Face indices to save subsurface temperature of the secondary
 """
-function BinaryTPMResult(btpm::BinaryTPM, ephem, times_to_save::Vector{Float64}, face_ID_pri::Vector{Int}, face_ID_sec::Vector{Int})
-    result_pri = SingleTPMResult(btpm.pri, ephem, times_to_save, face_ID_pri)
-    result_sec = SingleTPMResult(btpm.sec, ephem, times_to_save, face_ID_sec)
+function BinaryAsteroidThermoPhysicalModelResult(btpm::BinaryAsteroidThermoPhysicalModel, ephem, times_to_save::Vector{Float64}, face_ID_pri::Vector{Int}, face_ID_sec::Vector{Int})
+    result_pri = SingleAsteroidThermoPhysicalModelResult(btpm.pri, ephem, times_to_save, face_ID_pri)
+    result_sec = SingleAsteroidThermoPhysicalModelResult(btpm.sec, ephem, times_to_save, face_ID_sec)
 
-    return BinaryTPMResult(result_pri, result_sec)
+    return BinaryAsteroidThermoPhysicalModelResult(result_pri, result_sec)
 end
 
 
 """
-    update_TPM_result!(result::SingleTPMResult, stpm::SingleTPM, i_time::Integer)
+    update_TPM_result!(result::SingleAsteroidThermoPhysicalModelResult, stpm::SingleAsteroidThermoPhysicalModel, i_time::Integer)
 
 Save the results of TPM at the time step `i_time` to `result`.
 
 # Arguments
-- `result` : Output data format for `SingleTPM`
+- `result` : Output data format for `SingleAsteroidThermoPhysicalModel`
 - `stpm`   : Thermophysical model for a single asteroid
 - `i_time` : Time step to save data
 """
-function update_TPM_result!(result::SingleTPMResult, stpm::SingleTPM, i_time::Integer)
+function update_TPM_result!(result::SingleAsteroidThermoPhysicalModelResult, stpm::SingleAsteroidThermoPhysicalModel, i_time::Integer)
     result.E_in[i_time]   = energy_in(stpm)
     result.E_out[i_time]  = energy_out(stpm)
     result.force[i_time]  = stpm.force
@@ -387,26 +387,26 @@ end
 
 
 """
-    update_TPM_result!(result::BinaryTPMResult, btpm::BinaryTPM, ephem, i_time::Integer)
+    update_TPM_result!(result::BinaryAsteroidThermoPhysicalModelResult, btpm::BinaryAsteroidThermoPhysicalModel, ephem, i_time::Integer)
 
 Save the results of TPM at the time step `i_time` to `result`.
 
 # Arguments
-- `result` : Output data format for `BinaryTPM`
+- `result` : Output data format for `BinaryAsteroidThermoPhysicalModel`
 - `btpm`   : Thermophysical model for a binary asteroid
 - `ephem`  : Ephemerides
 - `i_time`     : Time step
 """
-function update_TPM_result!(result::BinaryTPMResult, btpm::BinaryTPM, i_time::Integer)
+function update_TPM_result!(result::BinaryAsteroidThermoPhysicalModelResult, btpm::BinaryAsteroidThermoPhysicalModel, i_time::Integer)
     update_TPM_result!(result.pri, btpm.pri, i_time)
     update_TPM_result!(result.sec, btpm.sec, i_time)
 end
 
 
 """
-    export_TPM_results(dirpath, result::SingleTPMResult)
+    export_TPM_results(dirpath, result::SingleAsteroidThermoPhysicalModelResult)
 
-Export the result of `SingleTPM` to CSV files. 
+Export the result of `SingleAsteroidThermoPhysicalModel` to CSV files. 
 The output files are saved in the following directory structure:
 
     dirpath
@@ -417,9 +417,9 @@ The output files are saved in the following directory structure:
 
 # Arguments
 - `dirpath` : Path to the directory to save CSV files.
-- `result`  : Output data format for `SingleTPM`
+- `result`  : Output data format for `SingleAsteroidThermoPhysicalModel`
 """
-function export_TPM_results(dirpath, result::SingleTPMResult)
+function export_TPM_results(dirpath, result::SingleAsteroidThermoPhysicalModelResult)
     
     df = DataFrame()
     df.time     = result.times
@@ -488,9 +488,9 @@ end
 
 
 """
-    export_TPM_results(dirpath, result::BinaryTPMResult)
+    export_TPM_results(dirpath, result::BinaryAsteroidThermoPhysicalModelResult)
 
-Export the result of `BinaryTPM` to CSV files. 
+Export the result of `BinaryAsteroidThermoPhysicalModel` to CSV files. 
 The output files are saved in the following directory structure:
 
     dirpath
@@ -507,9 +507,9 @@ The output files are saved in the following directory structure:
 
 # Arguments
 - `dirpath` : Path to the directory to save CSV files.
-- `result`  : Output data format for `BinaryTPM`
+- `result`  : Output data format for `BinaryAsteroidThermoPhysicalModel`
 """
-function export_TPM_results(dirpath, result::BinaryTPMResult)
+function export_TPM_results(dirpath, result::BinaryAsteroidThermoPhysicalModelResult)
     dirpath_pri = joinpath(dirpath, "pri")
     dirpath_sec = joinpath(dirpath, "sec")
 
@@ -543,7 +543,7 @@ end
 
 
 """
-    init_temperature!(stpm::SingleTPM, T₀::Real)
+    init_temperature!(stpm::SingleAsteroidThermoPhysicalModel, T₀::Real)
 
 Initialize all temperature cells at the given temperature `T₀`
 
@@ -551,13 +551,13 @@ Initialize all temperature cells at the given temperature `T₀`
 - `stpm` : Thermophysical model for a single asteroid
 - `T₀`   : Initial temperature of all cells [K]
 """
-function init_temperature!(stpm::SingleTPM, T₀::Real)
+function init_temperature!(stpm::SingleAsteroidThermoPhysicalModel, T₀::Real)
     stpm.temperature .= T₀
 end
 
 
 """
-    init_temperature!(btpm::BinaryTPM, T₀::Real)
+    init_temperature!(btpm::BinaryTBinaryAsteroidThermoPhysicalModelPM, T₀::Real)
 
 Initialize all temperature cells at the given temperature `T₀`
 
@@ -565,7 +565,7 @@ Initialize all temperature cells at the given temperature `T₀`
 - `btpm` : Thermophysical model for a binary asteroid
 - `T₀`   : Initial temperature of all cells [K]
 """
-function init_temperature!(btpm::BinaryTPM, T₀::Real)
+function init_temperature!(btpm::BinaryAsteroidThermoPhysicalModel, T₀::Real)
     init_temperature!(btpm.pri, T₀)
     init_temperature!(btpm.sec, T₀)
 end
@@ -620,7 +620,7 @@ end
 # end
 
 """
-    run_TPM!(stpm::SingleTPM, ephem, savepath)
+    run_TPM!(stpm::SingleAsteroidThermoPhysicalModel, ephem, savepath)
 
 Run TPM for a single asteroid.
 
@@ -635,9 +635,9 @@ Run TPM for a single asteroid.
 # Keyword arguments
 - `show_progress` : Flag to show the progress meter
 """
-function run_TPM!(stpm::SingleTPM, ephem, times_to_save::Vector{Float64}, face_ID::Vector{Int}; show_progress=true)
+function run_TPM!(stpm::SingleAsteroidThermoPhysicalModel, ephem, times_to_save::Vector{Float64}, face_ID::Vector{Int}; show_progress=true)
 
-    result = SingleTPMResult(stpm, ephem, times_to_save, face_ID)
+    result = SingleAsteroidThermoPhysicalModelResult(stpm, ephem, times_to_save, face_ID)
 
     ## ProgressMeter setting
     if show_progress
@@ -674,7 +674,7 @@ function run_TPM!(stpm::SingleTPM, ephem, times_to_save::Vector{Float64}, face_I
 end
 
 """
-    run_TPM!(btpm::BinaryTPM, ephem, savepath)
+    run_TPM!(btpm::BinaryAsteroidThermoPhysicalModel, ephem, savepath)
 
 Run TPM for a binary asteroid.
 
@@ -694,9 +694,9 @@ Run TPM for a binary asteroid.
 # Keyword arguments
 - `show_progress` : Flag to show the progress meter
 """
-function run_TPM!(btpm::BinaryTPM, ephem, times_to_save::Vector{Float64}, face_ID_pri::Vector{Int}, face_ID_sec::Vector{Int}; show_progress=true)
+function run_TPM!(btpm::BinaryAsteroidThermoPhysicalModel, ephem, times_to_save::Vector{Float64}, face_ID_pri::Vector{Int}, face_ID_sec::Vector{Int}; show_progress=true)
 
-    result = BinaryTPMResult(btpm, ephem, times_to_save, face_ID_pri, face_ID_sec)
+    result = BinaryAsteroidThermoPhysicalModelResult(btpm, ephem, times_to_save, face_ID_pri, face_ID_sec)
 
     ## ProgressMeter setting
     if show_progress
@@ -739,4 +739,3 @@ function run_TPM!(btpm::BinaryTPM, ephem, times_to_save::Vector{Float64}, face_I
 
     return result
 end
-

--- a/src/TPM.jl
+++ b/src/TPM.jl
@@ -154,6 +154,9 @@ struct SingleAsteroidThermoPhysicalModel{P<:AbstractThermoParams, S<:HeatConduct
 end
 
 
+const SingleAsteroidTPM = SingleAsteroidThermoPhysicalModel  # Alias for the struct. `TPM` is a abbreviation for a "thermophysical model".
+
+
 """
     SingleAsteroidThermoPhysicalModel(shape, thermo_params; SELF_SHADOWING=true, SELF_HEATING=true) -> stpm
 
@@ -202,6 +205,9 @@ struct BinaryAsteroidThermoPhysicalModel{M1, M2} <: AbstractAsteroidTPM
     MUTUAL_SHADOWING ::Bool
     MUTUAL_HEATING   ::Bool
 end
+
+
+const BinaryAsteroidTPM = BinaryAsteroidThermoPhysicalModel
 
 
 """
@@ -267,6 +273,9 @@ struct SingleAsteroidThermoPhysicalModelResult
 end
 
 
+const SingleAsteroidTPMResult = SingleAsteroidThermoPhysicalModelResult  # Alias for the struct. `TPM` is a abbreviation for a "thermophysical model result".
+
+
 """
 Outer constructor of `SingleAsteroidThermoPhysicalModelResult`
 
@@ -323,6 +332,9 @@ struct BinaryAsteroidThermoPhysicalModelResult
     pri::SingleAsteroidThermoPhysicalModelResult
     sec::SingleAsteroidThermoPhysicalModelResult
 end
+
+
+const BinaryAsteroidTPMResult = BinaryAsteroidThermoPhysicalModelResult  # Alias for the struct. `TPM` is a abbreviation for a "thermophysical model result"
 
 
 """

--- a/src/TPM.jl
+++ b/src/TPM.jl
@@ -580,49 +580,6 @@ end
 # ****************************************************************
 
 
-# """
-# """
-# function run_TPM!(shape::ShapeModel, orbit::OrbitalElements, spin::SpinParams, thermo_params::AbstractThermoParams, savepath="tmp.jld2")
-#     @unpack P, Δt, t_begin, t_end = thermo_params
-    
-#     init_temperatures_zero!(shape, thermo_params)
-
-#     ts = (t_begin:Δt:t_end) * P
-#     timestamp = prep_timestamp(ts)
-#     # surface_temperature_table = zeros(length(shape.faces), Int(1/thermo_params.Δt)-1)
-
-#     for (i, t) in enumerate(ts)
-#         update_orbit!(orbit, t)
-#         update_spin!(spin, t)
-            
-#         r̂☉ = normalize(orbit.r) * -1  # Shift the origin from the sun to the body
-#         r̂☉ = orbit_to_body(r̂☉, spin)
-        
-#         update_flux_sun!(shape, orbit.F☉, r̂☉)
-#         update_flux_scat_single!(shape, thermo_params)
-#         update_flux_rad_single!(shape, thermo_params)
-        
-#         update_force!(shape, thermo_params)
-#         sum_force_torque!(shape)
-        
-#         f = SVector{3}(shape.force)   # Body-fixed frame
-#         τ = SVector{3}(shape.torque)  # Body-fixed frame
-
-#         f = body_to_orbit(f, spin)  # Orbital plane frame
-#         τ = body_to_orbit(τ, spin)  # Orbital plane frame
-
-#         E_in, E_out, E_cons = energy_io(shape, thermo_params)
-
-#         save_timestamp!(timestamp, i, orbit.u, orbit.ν, spin.ϕ, f..., τ..., E_in, E_out, E_cons)
-        
-#         update_temperatures!(shape, thermo_params)
-#     end
-#     mean_energy_cons_frac!(timestamp, spin)
-#     jldsave(savepath; shape, orbit, spin, thermo_params, timestamp)
-
-#     timestamp
-# end
-
 """
     run_TPM!(stpm::SingleAsteroidThermoPhysicalModel, ephem, savepath)
 

--- a/src/TPM.jl
+++ b/src/TPM.jl
@@ -265,9 +265,6 @@ struct SingleAsteroidThermoPhysicalModelResult
 end
 
 
-const SingleAsteroidTPMResult = SingleAsteroidThermoPhysicalModelResult  # Alias for the struct. `TPM` is a abbreviation for a "thermophysical model result".
-
-
 """
 Outer constructor of `SingleAsteroidThermoPhysicalModelResult`
 
@@ -324,9 +321,6 @@ struct BinaryAsteroidThermoPhysicalModelResult
     pri::SingleAsteroidThermoPhysicalModelResult
     sec::SingleAsteroidThermoPhysicalModelResult
 end
-
-
-const BinaryAsteroidTPMResult = BinaryAsteroidThermoPhysicalModelResult  # Alias for the struct. `TPM` is a abbreviation for a "thermophysical model result"
 
 
 """

--- a/src/TPM.jl
+++ b/src/TPM.jl
@@ -101,13 +101,16 @@ end
 
 
 """
-Abstract type of a thermophysical model
+Abstract type of an asteroid's thermophysical model.
+The `AbstractAsteroidTPM` type is an alias for `AbstractAsteroidThermoPhysicalModel`.
 """
-abstract type ThermoPhysicalModel end
+abstract type AbstractAsteroidThermoPhysicalModel end
+
+const AbstractAsteroidTPM = AbstractAsteroidThermoPhysicalModel  # Alias for the abstract type. `TPM` is a abbreviation for a "thermophysical model".
 
 
 """
-    struct SingleTPM <: ThermoPhysicalModel
+    struct SingleTPM <: AbstractAsteroidTPM
 
 # Fields
 - `shape`          : Shape model
@@ -132,7 +135,7 @@ abstract type ThermoPhysicalModel end
 # TODO:
 - roughness_maps   ::ShapeModel[]
 """
-struct SingleTPM{P<:AbstractThermoParams, S<:HeatConductionSolver, BU<:BoundaryCondition, BL<:BoundaryCondition} <: ThermoPhysicalModel
+struct SingleTPM{P<:AbstractThermoParams, S<:HeatConductionSolver, BU<:BoundaryCondition, BL<:BoundaryCondition} <: AbstractAsteroidTPM
     shape          ::ShapeModel
     thermo_params  ::P
 
@@ -184,7 +187,7 @@ end
 
 
 """
-    struct BinaryTPM{M1, M2} <: ThermoPhysicalModel
+    struct BinaryTPM{M1, M2} <: AbstractAsteroidTPM
 
 # Fields
 - `pri`              : TPM for the primary
@@ -192,7 +195,7 @@ end
 - `MUTUAL_SHADOWING` : Flag to consider mutual shadowing
 - `MUTUAL_HEATING`   : Flag to consider mutual heating
 """
-struct BinaryTPM{M1, M2} <: ThermoPhysicalModel
+struct BinaryTPM{M1, M2} <: AbstractAsteroidTPM
     pri              ::M1
     sec              ::M2
 

--- a/src/energy_flux.jl
+++ b/src/energy_flux.jl
@@ -20,11 +20,11 @@ flux_total(R_vis, R_ir, F_sun, F_scat, F_rad) = (1 - R_vis) * F_sun + (1 - R_vis
 
 
 """
-    energy_in(stpm::SingleAsteroidThermoPhysicalModel) -> E_in
+    energy_in(stpm::SingleAsteroidTPM) -> E_in
 
 Input energy per second on the whole surface [W]
 """
-function energy_in(stpm::SingleAsteroidThermoPhysicalModel)
+function energy_in(stpm::SingleAsteroidTPM)
     E_in = 0.
     for i in eachindex(stpm.shape.faces)
         R_vis  = stpm.thermo_params.reflectance_vis[i]
@@ -41,14 +41,14 @@ end
 
 
 """
-    energy_out(stpm::SingleAsteroidThermoPhysicalModel) -> E_out
+    energy_out(stpm::SingleAsteroidTPM) -> E_out
 
 Output enegey per second from the whole surface [W]
 
 # Arguments
 - `stpm` : Thermophysical model for a single asteroid
 """
-function energy_out(stpm::SingleAsteroidThermoPhysicalModel)
+function energy_out(stpm::SingleAsteroidTPM)
     E_out = 0.
     for i in eachindex(stpm.shape.faces)
         ε = stpm.thermo_params.emissivity[i]
@@ -67,7 +67,7 @@ end
 
 
 """
-    update_flux_sun!(stpm::SingleAsteroidThermoPhysicalModel, r̂☉::StaticVector{3}, F☉::Real)
+    update_flux_sun!(stpm::SingleAsteroidTPM, r̂☉::StaticVector{3}, F☉::Real)
 
 Update solar irradiation flux on every face of a shape model.
 
@@ -75,7 +75,7 @@ Update solar irradiation flux on every face of a shape model.
 - `r̂☉`    : Normalized vector indicating the direction of the sun in the body-fixed frame
 - `F☉`    : Solar radiation flux [W/m²]
 """
-function update_flux_sun!(stpm::SingleAsteroidThermoPhysicalModel, r̂☉::StaticVector{3}, F☉::Real)
+function update_flux_sun!(stpm::SingleAsteroidTPM, r̂☉::StaticVector{3}, F☉::Real)
     r̂☉ = normalize(r̂☉)
 
     if stpm.SELF_SHADOWING
@@ -101,7 +101,7 @@ end
 
 
 """
-    update_flux_sun!(stpm::SingleAsteroidThermoPhysicalModel, r☉::StaticVector{3})
+    update_flux_sun!(stpm::SingleAsteroidTPM, r☉::StaticVector{3})
 
 Update solar irradiation flux on every face of a shape model.
 
@@ -109,7 +109,7 @@ Update solar irradiation flux on every face of a shape model.
 - `stpm` : Thermophysical model for a single asteroid
 - `r☉`   : Position of the sun in the body-fixed frame (NOT normalized)
 """
-function update_flux_sun!(stpm::SingleAsteroidThermoPhysicalModel, r☉::StaticVector{3})
+function update_flux_sun!(stpm::SingleAsteroidTPM, r☉::StaticVector{3})
     r̂☉ = SVector{3}(normalize(r☉))
     F☉ = SOLAR_CONST / (norm(r☉) * m2au)^2
 
@@ -118,14 +118,14 @@ end
 
 
 """
-    update_flux_sun!(btpm::BinaryAsteroidThermoPhysicalModel, r☉₁::StaticVector{3}, r☉₂::StaticVector{3})
+    update_flux_sun!(btpm::BinaryAsteroidTPM, r☉₁::StaticVector{3}, r☉₂::StaticVector{3})
 
 # Arguments
 - `btpm` : Thermophysical model for a binary asteroid
 - `r☉₁`  : Sun's position in the body-fixed frame of the primary, which is not normalized.
 - `r☉₂`  : Sun's position in the body-fixed frame of the secondary, which is not normalized.
 """
-function update_flux_sun!(btpm::BinaryAsteroidThermoPhysicalModel, r☉₁::StaticVector{3}, r☉₂::StaticVector{3})
+function update_flux_sun!(btpm::BinaryAsteroidTPM, r☉₁::StaticVector{3}, r☉₂::StaticVector{3})
     update_flux_sun!(btpm.pri, r☉₁)
     update_flux_sun!(btpm.sec, r☉₂)
 end
@@ -136,14 +136,14 @@ end
 # ****************************************************************
 
 """
-    update_flux_scat_single!(stpm::SingleAsteroidThermoPhysicalModel)
+    update_flux_scat_single!(stpm::SingleAsteroidTPM)
 
 Update flux of scattered sunlight, only considering single scattering.
 
 # Arguments
 - `stpm` : Thermophysical model for a single asteroid
 """
-function update_flux_scat_single!(stpm::SingleAsteroidThermoPhysicalModel)
+function update_flux_scat_single!(stpm::SingleAsteroidTPM)
     stpm.SELF_HEATING == false && return
 
     for i_face in eachindex(stpm.shape.faces)
@@ -160,14 +160,14 @@ end
 
 
 """
-    update_flux_scat_single!(btpm::BinaryAsteroidThermoPhysicalModel)
+    update_flux_scat_single!(btpm::BinaryAsteroidTPM)
 
 Update flux of scattered sunlight, only considering single scattering.
 
 # Arguments
 - `btpm` : Thermophysical model for a binary asteroid
 """
-function update_flux_scat_single!(btpm::BinaryAsteroidThermoPhysicalModel)
+function update_flux_scat_single!(btpm::BinaryAsteroidTPM)
     update_flux_scat_single!(btpm.pri)
     update_flux_scat_single!(btpm.sec)
 end
@@ -188,7 +188,7 @@ end
 # ****************************************************************
 
 """
-    update_flux_rad_single!(stpm::SingleAsteroidThermoPhysicalModel)
+    update_flux_rad_single!(stpm::SingleAsteroidTPM)
 
 Update flux of absorption of thermal radiation from surrounding surface.
 Single radiation-absorption is only considered, assuming albedo is close to zero at thermal infrared wavelength.
@@ -196,7 +196,7 @@ Single radiation-absorption is only considered, assuming albedo is close to zero
 # Arguments
 - `stpm` : Thermophysical model for a single asteroid
 """
-function update_flux_rad_single!(stpm::SingleAsteroidThermoPhysicalModel)
+function update_flux_rad_single!(stpm::SingleAsteroidTPM)
     stpm.SELF_HEATING == false && return
 
     for i in eachindex(stpm.shape.faces)
@@ -215,7 +215,7 @@ end
 
 
 """
-    update_flux_rad_single!(btpm::BinaryAsteroidThermoPhysicalModel)
+    update_flux_rad_single!(btpm::BinaryAsteroidTPM)
 
 Update flux of absorption of thermal radiation from surrounding surface.
 Single radiation-absorption is only considered, assuming albedo is close to zero at thermal infrared wavelength.
@@ -223,7 +223,7 @@ Single radiation-absorption is only considered, assuming albedo is close to zero
 # Arguments
 - `btpm` : Thermophysical model for a binary asteroid
 """
-function update_flux_rad_single!(btpm::BinaryAsteroidThermoPhysicalModel)
+function update_flux_rad_single!(btpm::BinaryAsteroidTPM)
     update_flux_rad_single!(btpm.pri)
     update_flux_rad_single!(btpm.sec)
 end
@@ -235,7 +235,7 @@ end
 
 
 """
-    mutual_shadowing!(btpm::BinaryAsteroidThermoPhysicalModel, r☉, rₛ, R₂₁)
+    mutual_shadowing!(btpm::BinaryAsteroidTPM, r☉, rₛ, R₂₁)
 
 Detect eclipse events between the primary and secondary, and update the solar fluxes of the faces.
 
@@ -245,7 +245,7 @@ Detect eclipse events between the primary and secondary, and update the solar fl
 - `rₛ`   : Position of the secondary relative to the primary (NOT normalized)
 - `R₂₁`  : Rotation matrix from secondary to primary
 """
-function mutual_shadowing!(btpm::BinaryAsteroidThermoPhysicalModel, r☉, rₛ, R₂₁)
+function mutual_shadowing!(btpm::BinaryAsteroidTPM, r☉, rₛ, R₂₁)
     btpm.MUTUAL_SHADOWING == false && return
 
     shape1 = btpm.pri.shape
@@ -379,7 +379,7 @@ end
 
 
 """
-    mutual_heating!(btpm::BinaryAsteroidThermoPhysicalModel, rₛ, R₂₁)
+    mutual_heating!(btpm::BinaryAsteroidTPM, rₛ, R₂₁)
 
 Calculate the mutual heating between the primary and secondary asteroids.
 
@@ -391,7 +391,7 @@ Calculate the mutual heating between the primary and secondary asteroids.
 # TODO
 - Need to consider local horizon?
 """
-function mutual_heating!(btpm::BinaryAsteroidThermoPhysicalModel, rₛ, R₂₁)
+function mutual_heating!(btpm::BinaryAsteroidTPM, rₛ, R₂₁)
     btpm.MUTUAL_HEATING == false && return
 
     shape1 = btpm.pri.shape

--- a/src/energy_flux.jl
+++ b/src/energy_flux.jl
@@ -20,11 +20,11 @@ flux_total(R_vis, R_ir, F_sun, F_scat, F_rad) = (1 - R_vis) * F_sun + (1 - R_vis
 
 
 """
-    energy_in(stpm::SingleTPM) -> E_in
+    energy_in(stpm::SingleAsteroidThermoPhysicalModel) -> E_in
 
 Input energy per second on the whole surface [W]
 """
-function energy_in(stpm::SingleTPM)
+function energy_in(stpm::SingleAsteroidThermoPhysicalModel)
     E_in = 0.
     for i in eachindex(stpm.shape.faces)
         R_vis  = stpm.thermo_params.reflectance_vis[i]
@@ -41,14 +41,14 @@ end
 
 
 """
-    energy_out(stpm::SingleTPM) -> E_out
+    energy_out(stpm::SingleAsteroidThermoPhysicalModel) -> E_out
 
 Output enegey per second from the whole surface [W]
 
 # Arguments
 - `stpm` : Thermophysical model for a single asteroid
 """
-function energy_out(stpm::SingleTPM)
+function energy_out(stpm::SingleAsteroidThermoPhysicalModel)
     E_out = 0.
     for i in eachindex(stpm.shape.faces)
         ε = stpm.thermo_params.emissivity[i]
@@ -67,7 +67,7 @@ end
 
 
 """
-    update_flux_sun!(stpm::SingleTPM, r̂☉::StaticVector{3}, F☉::Real)
+    update_flux_sun!(stpm::SingleAsteroidThermoPhysicalModel, r̂☉::StaticVector{3}, F☉::Real)
 
 Update solar irradiation flux on every face of a shape model.
 
@@ -75,7 +75,7 @@ Update solar irradiation flux on every face of a shape model.
 - `r̂☉`    : Normalized vector indicating the direction of the sun in the body-fixed frame
 - `F☉`    : Solar radiation flux [W/m²]
 """
-function update_flux_sun!(stpm::SingleTPM, r̂☉::StaticVector{3}, F☉::Real)
+function update_flux_sun!(stpm::SingleAsteroidThermoPhysicalModel, r̂☉::StaticVector{3}, F☉::Real)
     r̂☉ = normalize(r̂☉)
 
     if stpm.SELF_SHADOWING
@@ -101,7 +101,7 @@ end
 
 
 """
-    update_flux_sun!(stpm::SingleTPM, r☉::StaticVector{3})
+    update_flux_sun!(stpm::SingleAsteroidThermoPhysicalModel, r☉::StaticVector{3})
 
 Update solar irradiation flux on every face of a shape model.
 
@@ -109,7 +109,7 @@ Update solar irradiation flux on every face of a shape model.
 - `stpm` : Thermophysical model for a single asteroid
 - `r☉`   : Position of the sun in the body-fixed frame (NOT normalized)
 """
-function update_flux_sun!(stpm::SingleTPM, r☉::StaticVector{3})
+function update_flux_sun!(stpm::SingleAsteroidThermoPhysicalModel, r☉::StaticVector{3})
     r̂☉ = SVector{3}(normalize(r☉))
     F☉ = SOLAR_CONST / (norm(r☉) * m2au)^2
 
@@ -118,14 +118,14 @@ end
 
 
 """
-    update_flux_sun!(btpm::BinaryTPM, r☉₁::StaticVector{3}, r☉₂::StaticVector{3})
+    update_flux_sun!(btpm::BinaryAsteroidThermoPhysicalModel, r☉₁::StaticVector{3}, r☉₂::StaticVector{3})
 
 # Arguments
 - `btpm` : Thermophysical model for a binary asteroid
 - `r☉₁`  : Sun's position in the body-fixed frame of the primary, which is not normalized.
 - `r☉₂`  : Sun's position in the body-fixed frame of the secondary, which is not normalized.
 """
-function update_flux_sun!(btpm::BinaryTPM, r☉₁::StaticVector{3}, r☉₂::StaticVector{3})
+function update_flux_sun!(btpm::BinaryAsteroidThermoPhysicalModel, r☉₁::StaticVector{3}, r☉₂::StaticVector{3})
     update_flux_sun!(btpm.pri, r☉₁)
     update_flux_sun!(btpm.sec, r☉₂)
 end
@@ -136,14 +136,14 @@ end
 # ****************************************************************
 
 """
-    update_flux_scat_single!(stpm::SingleTPM)
+    update_flux_scat_single!(stpm::SingleAsteroidThermoPhysicalModel)
 
 Update flux of scattered sunlight, only considering single scattering.
 
 # Arguments
 - `stpm` : Thermophysical model for a single asteroid
 """
-function update_flux_scat_single!(stpm::SingleTPM)
+function update_flux_scat_single!(stpm::SingleAsteroidThermoPhysicalModel)
     stpm.SELF_HEATING == false && return
 
     for i_face in eachindex(stpm.shape.faces)
@@ -160,14 +160,14 @@ end
 
 
 """
-    update_flux_scat_single!(btpm::BinaryTPM)
+    update_flux_scat_single!(btpm::BinaryAsteroidThermoPhysicalModel)
 
 Update flux of scattered sunlight, only considering single scattering.
 
 # Arguments
 - `btpm` : Thermophysical model for a binary asteroid
 """
-function update_flux_scat_single!(btpm::BinaryTPM)
+function update_flux_scat_single!(btpm::BinaryAsteroidThermoPhysicalModel)
     update_flux_scat_single!(btpm.pri)
     update_flux_scat_single!(btpm.sec)
 end
@@ -188,7 +188,7 @@ end
 # ****************************************************************
 
 """
-    update_flux_rad_single!(stpm::SingleTPM)
+    update_flux_rad_single!(stpm::SingleAsteroidThermoPhysicalModel)
 
 Update flux of absorption of thermal radiation from surrounding surface.
 Single radiation-absorption is only considered, assuming albedo is close to zero at thermal infrared wavelength.
@@ -196,7 +196,7 @@ Single radiation-absorption is only considered, assuming albedo is close to zero
 # Arguments
 - `stpm` : Thermophysical model for a single asteroid
 """
-function update_flux_rad_single!(stpm::SingleTPM)
+function update_flux_rad_single!(stpm::SingleAsteroidThermoPhysicalModel)
     stpm.SELF_HEATING == false && return
 
     for i in eachindex(stpm.shape.faces)
@@ -215,7 +215,7 @@ end
 
 
 """
-    update_flux_rad_single!(btpm::BinaryTPM)
+    update_flux_rad_single!(btpm::BinaryAsteroidThermoPhysicalModel)
 
 Update flux of absorption of thermal radiation from surrounding surface.
 Single radiation-absorption is only considered, assuming albedo is close to zero at thermal infrared wavelength.
@@ -223,7 +223,7 @@ Single radiation-absorption is only considered, assuming albedo is close to zero
 # Arguments
 - `btpm` : Thermophysical model for a binary asteroid
 """
-function update_flux_rad_single!(btpm::BinaryTPM)
+function update_flux_rad_single!(btpm::BinaryAsteroidThermoPhysicalModel)
     update_flux_rad_single!(btpm.pri)
     update_flux_rad_single!(btpm.sec)
 end
@@ -235,7 +235,7 @@ end
 
 
 """
-    mutual_shadowing!(btpm::BinaryTPM, r☉, rₛ, R₂₁)
+    mutual_shadowing!(btpm::BinaryAsteroidThermoPhysicalModel, r☉, rₛ, R₂₁)
 
 Detect eclipse events between the primary and secondary, and update the solar fluxes of the faces.
 
@@ -245,7 +245,7 @@ Detect eclipse events between the primary and secondary, and update the solar fl
 - `rₛ`   : Position of the secondary relative to the primary (NOT normalized)
 - `R₂₁`  : Rotation matrix from secondary to primary
 """
-function mutual_shadowing!(btpm::BinaryTPM, r☉, rₛ, R₂₁)
+function mutual_shadowing!(btpm::BinaryAsteroidThermoPhysicalModel, r☉, rₛ, R₂₁)
     btpm.MUTUAL_SHADOWING == false && return
 
     shape1 = btpm.pri.shape
@@ -379,7 +379,7 @@ end
 
 
 """
-    mutual_heating!(btpm::BinaryTPM, rₛ, R₂₁)
+    mutual_heating!(btpm::BinaryAsteroidThermoPhysicalModel, rₛ, R₂₁)
 
 Calculate the mutual heating between the primary and secondary asteroids.
 
@@ -391,7 +391,7 @@ Calculate the mutual heating between the primary and secondary asteroids.
 # TODO
 - Need to consider local horizon?
 """
-function mutual_heating!(btpm::BinaryTPM, rₛ, R₂₁)
+function mutual_heating!(btpm::BinaryAsteroidThermoPhysicalModel, rₛ, R₂₁)
     btpm.MUTUAL_HEATING == false && return
 
     shape1 = btpm.pri.shape

--- a/src/heat_conduction.jl
+++ b/src/heat_conduction.jl
@@ -5,7 +5,7 @@
 # ****************************************************************
 
 """
-    update_temperature!(stpm::SingleTPM, Δt)
+    update_temperature!(stpm::SingleAsteroidThermoPhysicalModel, Δt)
 
 Calculate the temperature for the next time step based on 1D heat conduction equation.
 If the thermal inertia (conductivity) is zero, omit to solve the heat conduction equation.
@@ -15,7 +15,7 @@ The surface termperature is determined only by radiative equilibrium.
 - `stpm` : Thermophysical model for a single asteroid
 - `Δt`   : Time step [sec]
 """
-function update_temperature!(stpm::SingleTPM, Δt)
+function update_temperature!(stpm::SingleAsteroidThermoPhysicalModel, Δt)
     if stpm.SOLVER isa ForwardEulerSolver
         forward_euler!(stpm, Δt)
     elseif stpm.SOLVER isa BackwardEulerSolver
@@ -29,7 +29,7 @@ end
 
 
 """
-    update_temperature!(btpm::BinaryTPM, Δt)
+    update_temperature!(btpm::BinaryAsteroidThermoPhysicalModel, Δt)
 
 Calculate the temperature for the next time step based on 1D heat conductivity equation.
 
@@ -37,7 +37,7 @@ Calculate the temperature for the next time step based on 1D heat conductivity e
 - `btpm` : Thermophysical model for a binary asteroid
 - `Δt`   : Time step [sec]
 """
-function update_temperature!(btpm::BinaryTPM, Δt)
+function update_temperature!(btpm::BinaryAsteroidThermoPhysicalModel, Δt)
     update_temperature!(btpm.pri, Δt)
     update_temperature!(btpm.sec, Δt)
 end
@@ -48,7 +48,7 @@ end
 
 
 """
-    forward_euler!(stpm::SingleTPM, Δt)
+    forward_euler!(stpm::SingleAsteroidThermoPhysicalModel, Δt)
 
 Predict the temperature at the next time step by the forward Euler method.
 - Explicit in time
@@ -59,7 +59,7 @@ In this function, the heat conduction equation is non-dimensionalized in time an
 - `stpm` : Thermophysical model for a single asteroid
 - `Δt`   : Time step [sec]
 """
-function forward_euler!(stpm::SingleTPM, Δt)
+function forward_euler!(stpm::SingleAsteroidThermoPhysicalModel, Δt)
     T = stpm.temperature
     n_depth = size(T, 1)
     n_face = size(T, 2)
@@ -102,7 +102,7 @@ end
 
 
 """
-    backward_euler!(stpm::SingleTPM, Δt)
+    backward_euler!(stpm::SingleAsteroidThermoPhysicalModel, Δt)
 
 Predict the temperature at the next time step by the backward Euler method.
 - Implicit in time (Unconditionally stable in the heat conduction equation)
@@ -110,7 +110,7 @@ Predict the temperature at the next time step by the backward Euler method.
 - Second order in space
 In this function, the heat conduction equation is non-dimensionalized in time and length.
 """
-function backward_euler!(stpm::SingleTPM, Δt)
+function backward_euler!(stpm::SingleAsteroidThermoPhysicalModel, Δt)
     # T = stpm.temperature
     # n_depth = size(T, 1)
     # n_face = size(T, 2)
@@ -143,7 +143,7 @@ end
 
 
 """
-    crank_nicolson!(stpm::SingleTPM, Δt)
+    crank_nicolson!(stpm::SingleAsteroidThermoPhysicalModel, Δt)
 
 Predict the temperature at the next time step by the Crank-Nicolson method.
 - Implicit in time (Unconditionally stable in the heat conduction equation)
@@ -151,7 +151,7 @@ Predict the temperature at the next time step by the Crank-Nicolson method.
 - Second order in space
 In this function, the heat conduction equation is non-dimensionalized in time and length.
 """
-function crank_nicolson!(stpm::SingleTPM, Δt)
+function crank_nicolson!(stpm::SingleAsteroidThermoPhysicalModel, Δt)
     # T = stpm.temperature
     # n_depth = size(T, 1)
     # n_face = size(T, 2)
@@ -192,7 +192,7 @@ end
 
 """
     tridiagonal_matrix_algorithm!(a, b, c, d, x)
-    tridiagonal_matrix_algorithm!(stpm::SingleTPM)
+    tridiagonal_matrix_algorithm!(stpm::SingleAsteroidThermoPhysicalModel)
 
 Tridiagonal matrix algorithm to solve the heat conduction equation by the backward Euler and Crank-Nicolson methods.
 
@@ -222,7 +222,7 @@ function tridiagonal_matrix_algorithm!(a, b, c, d, x)
     end
 end
 
-tridiagonal_matrix_algorithm!(stpm::SingleTPM) = tridiagonal_matrix_algorithm!(stpm.SOLVER.a, stpm.SOLVER.b, stpm.SOLVER.c, stpm.SOLVER.d, stpm.SOLVER.x)
+tridiagonal_matrix_algorithm!(stpm::SingleAsteroidThermoPhysicalModel) = tridiagonal_matrix_algorithm!(stpm.SOLVER.a, stpm.SOLVER.b, stpm.SOLVER.c, stpm.SOLVER.d, stpm.SOLVER.x)
 
 
 # ****************************************************************
@@ -230,7 +230,7 @@ tridiagonal_matrix_algorithm!(stpm::SingleTPM) = tridiagonal_matrix_algorithm!(s
 # ****************************************************************
 
 """
-    update_upper_temperature!(stpm::SingleTPM, i::Integer)
+    update_upper_temperature!(stpm::SingleAsteroidThermoPhysicalModel, i::Integer)
 
 Update the temperature of the upper surface based on the boundary condition `stpm.BC_UPPER`.
 
@@ -238,7 +238,7 @@ Update the temperature of the upper surface based on the boundary condition `stp
 - `stpm` : Thermophysical model for a single asteroid
 - `i`    : Index of the face of the shape model
 """
-function update_upper_temperature!(stpm::SingleTPM, i::Integer)
+function update_upper_temperature!(stpm::SingleAsteroidThermoPhysicalModel, i::Integer)
 
     #### Radiation boundary condition ####
     if stpm.BC_UPPER isa RadiationBoundaryCondition
@@ -307,7 +307,7 @@ Update the temperature of the bottom surface based on the boundary condition `st
 # Arguments
 - `stpm`       : Thermophysical model for a single asteroid
 """
-function update_lower_temperature!(stpm::SingleTPM)
+function update_lower_temperature!(stpm::SingleAsteroidThermoPhysicalModel)
 
     #### Insulation boundary condition ####
     if stpm.BC_LOWER isa InsulationBoundaryCondition

--- a/src/heat_conduction.jl
+++ b/src/heat_conduction.jl
@@ -5,7 +5,7 @@
 # ****************************************************************
 
 """
-    update_temperature!(stpm::SingleAsteroidThermoPhysicalModel, Δt)
+    update_temperature!(stpm::SingleAsteroidTPM, Δt)
 
 Calculate the temperature for the next time step based on 1D heat conduction equation.
 If the thermal inertia (conductivity) is zero, omit to solve the heat conduction equation.
@@ -15,7 +15,7 @@ The surface termperature is determined only by radiative equilibrium.
 - `stpm` : Thermophysical model for a single asteroid
 - `Δt`   : Time step [sec]
 """
-function update_temperature!(stpm::SingleAsteroidThermoPhysicalModel, Δt)
+function update_temperature!(stpm::SingleAsteroidTPM, Δt)
     if stpm.SOLVER isa ForwardEulerSolver
         forward_euler!(stpm, Δt)
     elseif stpm.SOLVER isa BackwardEulerSolver
@@ -29,7 +29,7 @@ end
 
 
 """
-    update_temperature!(btpm::BinaryAsteroidThermoPhysicalModel, Δt)
+    update_temperature!(btpm::BinaryAsteroidTPM, Δt)
 
 Calculate the temperature for the next time step based on 1D heat conductivity equation.
 
@@ -37,7 +37,7 @@ Calculate the temperature for the next time step based on 1D heat conductivity e
 - `btpm` : Thermophysical model for a binary asteroid
 - `Δt`   : Time step [sec]
 """
-function update_temperature!(btpm::BinaryAsteroidThermoPhysicalModel, Δt)
+function update_temperature!(btpm::BinaryAsteroidTPM, Δt)
     update_temperature!(btpm.pri, Δt)
     update_temperature!(btpm.sec, Δt)
 end
@@ -48,7 +48,7 @@ end
 
 
 """
-    forward_euler!(stpm::SingleAsteroidThermoPhysicalModel, Δt)
+    forward_euler!(stpm::SingleAsteroidTPM, Δt)
 
 Predict the temperature at the next time step by the forward Euler method.
 - Explicit in time
@@ -59,7 +59,7 @@ In this function, the heat conduction equation is non-dimensionalized in time an
 - `stpm` : Thermophysical model for a single asteroid
 - `Δt`   : Time step [sec]
 """
-function forward_euler!(stpm::SingleAsteroidThermoPhysicalModel, Δt)
+function forward_euler!(stpm::SingleAsteroidTPM, Δt)
     T = stpm.temperature
     n_depth = size(T, 1)
     n_face = size(T, 2)
@@ -102,7 +102,7 @@ end
 
 
 """
-    backward_euler!(stpm::SingleAsteroidThermoPhysicalModel, Δt)
+    backward_euler!(stpm::SingleAsteroidTPM, Δt)
 
 Predict the temperature at the next time step by the backward Euler method.
 - Implicit in time (Unconditionally stable in the heat conduction equation)
@@ -110,7 +110,7 @@ Predict the temperature at the next time step by the backward Euler method.
 - Second order in space
 In this function, the heat conduction equation is non-dimensionalized in time and length.
 """
-function backward_euler!(stpm::SingleAsteroidThermoPhysicalModel, Δt)
+function backward_euler!(stpm::SingleAsteroidTPM, Δt)
     # T = stpm.temperature
     # n_depth = size(T, 1)
     # n_face = size(T, 2)
@@ -143,7 +143,7 @@ end
 
 
 """
-    crank_nicolson!(stpm::SingleAsteroidThermoPhysicalModel, Δt)
+    crank_nicolson!(stpm::SingleAsteroidTPM, Δt)
 
 Predict the temperature at the next time step by the Crank-Nicolson method.
 - Implicit in time (Unconditionally stable in the heat conduction equation)
@@ -151,7 +151,7 @@ Predict the temperature at the next time step by the Crank-Nicolson method.
 - Second order in space
 In this function, the heat conduction equation is non-dimensionalized in time and length.
 """
-function crank_nicolson!(stpm::SingleAsteroidThermoPhysicalModel, Δt)
+function crank_nicolson!(stpm::SingleAsteroidTPM, Δt)
     # T = stpm.temperature
     # n_depth = size(T, 1)
     # n_face = size(T, 2)
@@ -222,7 +222,7 @@ function tridiagonal_matrix_algorithm!(a, b, c, d, x)
     end
 end
 
-tridiagonal_matrix_algorithm!(stpm::SingleAsteroidThermoPhysicalModel) = tridiagonal_matrix_algorithm!(stpm.SOLVER.a, stpm.SOLVER.b, stpm.SOLVER.c, stpm.SOLVER.d, stpm.SOLVER.x)
+tridiagonal_matrix_algorithm!(stpm::SingleAsteroidTPM) = tridiagonal_matrix_algorithm!(stpm.SOLVER.a, stpm.SOLVER.b, stpm.SOLVER.c, stpm.SOLVER.d, stpm.SOLVER.x)
 
 
 # ****************************************************************
@@ -230,7 +230,7 @@ tridiagonal_matrix_algorithm!(stpm::SingleAsteroidThermoPhysicalModel) = tridiag
 # ****************************************************************
 
 """
-    update_upper_temperature!(stpm::SingleAsteroidThermoPhysicalModel, i::Integer)
+    update_upper_temperature!(stpm::SingleAsteroidTPM, i::Integer)
 
 Update the temperature of the upper surface based on the boundary condition `stpm.BC_UPPER`.
 
@@ -238,7 +238,7 @@ Update the temperature of the upper surface based on the boundary condition `stp
 - `stpm` : Thermophysical model for a single asteroid
 - `i`    : Index of the face of the shape model
 """
-function update_upper_temperature!(stpm::SingleAsteroidThermoPhysicalModel, i::Integer)
+function update_upper_temperature!(stpm::SingleAsteroidTPM, i::Integer)
 
     #### Radiation boundary condition ####
     if stpm.BC_UPPER isa RadiationBoundaryCondition
@@ -307,7 +307,7 @@ Update the temperature of the bottom surface based on the boundary condition `st
 # Arguments
 - `stpm`       : Thermophysical model for a single asteroid
 """
-function update_lower_temperature!(stpm::SingleAsteroidThermoPhysicalModel)
+function update_lower_temperature!(stpm::SingleAsteroidTPM)
 
     #### Insulation boundary condition ####
     if stpm.BC_LOWER isa InsulationBoundaryCondition
@@ -319,4 +319,3 @@ function update_lower_temperature!(stpm::SingleAsteroidThermoPhysicalModel)
         error("The lower boundary condition is not implemented.")
     end
 end
-

--- a/src/non_grav.jl
+++ b/src/non_grav.jl
@@ -5,14 +5,14 @@
 # ****************************************************************
 
 """
-    update_thermal_force!(stpm::SingleAsteroidThermoPhysicalModel)
+    update_thermal_force!(stpm::SingleAsteroidTPM)
 
 Calculate the thermal force and torque on every face and integrate them over all faces.
 
 # Arguments
 - `stpm` : Thermophysical model for a single asteroid
 """
-function update_thermal_force!(stpm::SingleAsteroidThermoPhysicalModel)
+function update_thermal_force!(stpm::SingleAsteroidTPM)
     stpm.force  .= 0.
     stpm.torque .= 0.
 
@@ -52,15 +52,14 @@ end
 
 
 """
-    update_thermal_force!(btpm::BinaryAsteroidThermoPhysicalModel)
+    update_thermal_force!(btpm::BinaryAsteroidTPM)
 
 Calculate the thermal force and torque on every face and integrate them over all faces.
 
 # Arguments
 - `btpm` : Thermophysical model for a binary asteroid
 """
-function update_thermal_force!(btpm::BinaryAsteroidThermoPhysicalModel)
+function update_thermal_force!(btpm::BinaryAsteroidTPM)
     update_thermal_force!(btpm.pri)
     update_thermal_force!(btpm.sec)
 end
-

--- a/src/non_grav.jl
+++ b/src/non_grav.jl
@@ -5,14 +5,14 @@
 # ****************************************************************
 
 """
-    update_thermal_force!(stpm::SingleTPM)
+    update_thermal_force!(stpm::SingleAsteroidThermoPhysicalModel)
 
 Calculate the thermal force and torque on every face and integrate them over all faces.
 
 # Arguments
 - `stpm` : Thermophysical model for a single asteroid
 """
-function update_thermal_force!(stpm::SingleTPM)
+function update_thermal_force!(stpm::SingleAsteroidThermoPhysicalModel)
     stpm.force  .= 0.
     stpm.torque .= 0.
 
@@ -52,14 +52,14 @@ end
 
 
 """
-    update_thermal_force!(btpm::BinaryTPM)
+    update_thermal_force!(btpm::BinaryAsteroidThermoPhysicalModel)
 
 Calculate the thermal force and torque on every face and integrate them over all faces.
 
 # Arguments
 - `btpm` : Thermophysical model for a binary asteroid
 """
-function update_thermal_force!(btpm::BinaryTPM)
+function update_thermal_force!(btpm::BinaryAsteroidThermoPhysicalModel)
     update_thermal_force!(btpm.pri)
     update_thermal_force!(btpm.sec)
 end

--- a/test/TPM_Didymos/TPM_Didymos.jl
+++ b/test/TPM_Didymos/TPM_Didymos.jl
@@ -131,7 +131,7 @@
     )
 
     ##= Setting of TPM =##
-    stpm1 = AsteroidThermoPhysicalModels.SingleTPM(shape1, thermo_params1;
+    stpm1 = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalModel(shape1, thermo_params1;
         SELF_SHADOWING = true,
         SELF_HEATING   = true,
         SOLVER         = AsteroidThermoPhysicalModels.ForwardEulerSolver(thermo_params1),
@@ -139,7 +139,7 @@
         BC_LOWER       = AsteroidThermoPhysicalModels.InsulationBoundaryCondition(),
     )
 
-    stpm2 = AsteroidThermoPhysicalModels.SingleTPM(shape2, thermo_params2;
+    stpm2 = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalModel(shape2, thermo_params2;
         SELF_SHADOWING = true,
         SELF_HEATING   = true,
         SOLVER         = AsteroidThermoPhysicalModels.ForwardEulerSolver(thermo_params2),
@@ -147,7 +147,7 @@
         BC_LOWER       = AsteroidThermoPhysicalModels.InsulationBoundaryCondition(),
     )
 
-    btpm  = AsteroidThermoPhysicalModels.BinaryTPM(stpm1, stpm2; MUTUAL_SHADOWING=true, MUTUAL_HEATING=true)
+    btpm  = AsteroidThermoPhysicalModels.BinaryAsteroidThermoPhysicalModel(stpm1, stpm2; MUTUAL_SHADOWING=true, MUTUAL_HEATING=true)
     AsteroidThermoPhysicalModels.init_temperature!(btpm, 200.)
     
     ##= Run TPM =##

--- a/test/TPM_Didymos/TPM_Didymos.jl
+++ b/test/TPM_Didymos/TPM_Didymos.jl
@@ -131,7 +131,7 @@
     )
 
     ##= Setting of TPM =##
-    stpm1 = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalModel(shape1, thermo_params1;
+    stpm1 = AsteroidThermoPhysicalModels.SingleAsteroidTPM(shape1, thermo_params1;
         SELF_SHADOWING = true,
         SELF_HEATING   = true,
         SOLVER         = AsteroidThermoPhysicalModels.ForwardEulerSolver(thermo_params1),
@@ -139,7 +139,7 @@
         BC_LOWER       = AsteroidThermoPhysicalModels.InsulationBoundaryCondition(),
     )
 
-    stpm2 = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalModel(shape2, thermo_params2;
+    stpm2 = AsteroidThermoPhysicalModels.SingleAsteroidTPM(shape2, thermo_params2;
         SELF_SHADOWING = true,
         SELF_HEATING   = true,
         SOLVER         = AsteroidThermoPhysicalModels.ForwardEulerSolver(thermo_params2),
@@ -147,7 +147,7 @@
         BC_LOWER       = AsteroidThermoPhysicalModels.InsulationBoundaryCondition(),
     )
 
-    btpm  = AsteroidThermoPhysicalModels.BinaryAsteroidThermoPhysicalModel(stpm1, stpm2; MUTUAL_SHADOWING=true, MUTUAL_HEATING=true)
+    btpm  = AsteroidThermoPhysicalModels.BinaryAsteroidTPM(stpm1, stpm2; MUTUAL_SHADOWING=true, MUTUAL_HEATING=true)
     AsteroidThermoPhysicalModels.init_temperature!(btpm, 200.)
     
     ##= Run TPM =##

--- a/test/TPM_Ryugu/TPM_Ryugu.jl
+++ b/test/TPM_Ryugu/TPM_Ryugu.jl
@@ -99,7 +99,7 @@
     )
 
     ##= Setting of TPM =##
-    stpm = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalModel(shape, thermo_params;
+    stpm = AsteroidThermoPhysicalModels.SingleAsteroidTPM(shape, thermo_params;
         SELF_SHADOWING = true,
         SELF_HEATING   = true,
         SOLVER         = AsteroidThermoPhysicalModels.ForwardEulerSolver(thermo_params),

--- a/test/TPM_Ryugu/TPM_Ryugu.jl
+++ b/test/TPM_Ryugu/TPM_Ryugu.jl
@@ -99,7 +99,7 @@
     )
 
     ##= Setting of TPM =##
-    stpm = AsteroidThermoPhysicalModels.SingleTPM(shape, thermo_params;
+    stpm = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalModel(shape, thermo_params;
         SELF_SHADOWING = true,
         SELF_HEATING   = true,
         SOLVER         = AsteroidThermoPhysicalModels.ForwardEulerSolver(thermo_params),

--- a/test/TPM_non-uniform_thermoparams/TPM_non-uniform_thermoparams.jl
+++ b/test/TPM_non-uniform_thermoparams/TPM_non-uniform_thermoparams.jl
@@ -114,7 +114,7 @@
     )
 
     ##= Setting of TPM =##
-    stpm = AsteroidThermoPhysicalModels.SingleTPM(shape, thermo_params;
+    stpm = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalModel(shape, thermo_params;
         SELF_SHADOWING = true,
         SELF_HEATING   = true,
         SOLVER         = AsteroidThermoPhysicalModels.ForwardEulerSolver(thermo_params),

--- a/test/TPM_zero-conductivity/TPM_zero-conductivity.jl
+++ b/test/TPM_zero-conductivity/TPM_zero-conductivity.jl
@@ -59,7 +59,7 @@
     )
 
     ##= Setting of TPM =##
-    stpm = AsteroidThermoPhysicalModels.SingleTPM(shape, thermo_params;
+    stpm = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalModel(shape, thermo_params;
         SELF_SHADOWING = true,
         SELF_HEATING   = false,
         SOLVER         = AsteroidThermoPhysicalModels.ForwardEulerSolver(thermo_params),

--- a/test/heat_conduction_1D.jl
+++ b/test/heat_conduction_1D.jl
@@ -54,9 +54,9 @@
     BC_UPPER       = AsteroidThermoPhysicalModels.IsothermalBoundaryCondition(0)
     BC_LOWER       = AsteroidThermoPhysicalModels.IsothermalBoundaryCondition(0)
 
-    stpm_FE = AsteroidThermoPhysicalModels.SingleTPM(shape, thermo_params; SELF_SHADOWING, SELF_HEATING, BC_UPPER, BC_LOWER, SOLVER=AsteroidThermoPhysicalModels.ForwardEulerSolver(thermo_params))
-    stpm_BE = AsteroidThermoPhysicalModels.SingleTPM(shape, thermo_params; SELF_SHADOWING, SELF_HEATING, BC_UPPER, BC_LOWER, SOLVER=AsteroidThermoPhysicalModels.BackwardEulerSolver(thermo_params))
-    stpm_CN = AsteroidThermoPhysicalModels.SingleTPM(shape, thermo_params; SELF_SHADOWING, SELF_HEATING, BC_UPPER, BC_LOWER, SOLVER=AsteroidThermoPhysicalModels.CrankNicolsonSolver(thermo_params))
+    stpm_FE = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalModel(shape, thermo_params; SELF_SHADOWING, SELF_HEATING, BC_UPPER, BC_LOWER, SOLVER=AsteroidThermoPhysicalModels.ForwardEulerSolver(thermo_params))
+    stpm_BE = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalModel(shape, thermo_params; SELF_SHADOWING, SELF_HEATING, BC_UPPER, BC_LOWER, SOLVER=AsteroidThermoPhysicalModels.BackwardEulerSolver(thermo_params))
+    stpm_CN = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalModel(shape, thermo_params; SELF_SHADOWING, SELF_HEATING, BC_UPPER, BC_LOWER, SOLVER=AsteroidThermoPhysicalModels.CrankNicolsonSolver(thermo_params))
 
     ##= Initial temperature =##
     T₀(x) = x < 0.5 ? 2x : 2(1 - x)

--- a/test/heat_conduction_1D.jl
+++ b/test/heat_conduction_1D.jl
@@ -54,9 +54,9 @@
     BC_UPPER       = AsteroidThermoPhysicalModels.IsothermalBoundaryCondition(0)
     BC_LOWER       = AsteroidThermoPhysicalModels.IsothermalBoundaryCondition(0)
 
-    stpm_FE = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalModel(shape, thermo_params; SELF_SHADOWING, SELF_HEATING, BC_UPPER, BC_LOWER, SOLVER=AsteroidThermoPhysicalModels.ForwardEulerSolver(thermo_params))
-    stpm_BE = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalModel(shape, thermo_params; SELF_SHADOWING, SELF_HEATING, BC_UPPER, BC_LOWER, SOLVER=AsteroidThermoPhysicalModels.BackwardEulerSolver(thermo_params))
-    stpm_CN = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalModel(shape, thermo_params; SELF_SHADOWING, SELF_HEATING, BC_UPPER, BC_LOWER, SOLVER=AsteroidThermoPhysicalModels.CrankNicolsonSolver(thermo_params))
+    stpm_FE = AsteroidThermoPhysicalModels.SingleAsteroidTPM(shape, thermo_params; SELF_SHADOWING, SELF_HEATING, BC_UPPER, BC_LOWER, SOLVER=AsteroidThermoPhysicalModels.ForwardEulerSolver(thermo_params))
+    stpm_BE = AsteroidThermoPhysicalModels.SingleAsteroidTPM(shape, thermo_params; SELF_SHADOWING, SELF_HEATING, BC_UPPER, BC_LOWER, SOLVER=AsteroidThermoPhysicalModels.BackwardEulerSolver(thermo_params))
+    stpm_CN = AsteroidThermoPhysicalModels.SingleAsteroidTPM(shape, thermo_params; SELF_SHADOWING, SELF_HEATING, BC_UPPER, BC_LOWER, SOLVER=AsteroidThermoPhysicalModels.CrankNicolsonSolver(thermo_params))
 
     ##= Initial temperature =##
     T₀(x) = x < 0.5 ? 2x : 2(1 - x)

--- a/test/thermal_radiation.jl
+++ b/test/thermal_radiation.jl
@@ -81,7 +81,7 @@
     )
 
     ##= Setting of TPM =##
-    stpm = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalModel(shape, thermo_params;
+    stpm = AsteroidThermoPhysicalModels.SingleAsteroidTPM(shape, thermo_params;
         SELF_SHADOWING = true,
         SELF_HEATING   = true,
         SOLVER         = AsteroidThermoPhysicalModels.ForwardEulerSolver(thermo_params),

--- a/test/thermal_radiation.jl
+++ b/test/thermal_radiation.jl
@@ -81,7 +81,7 @@
     )
 
     ##= Setting of TPM =##
-    stpm = AsteroidThermoPhysicalModels.SingleTPM(shape, thermo_params;
+    stpm = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalModel(shape, thermo_params;
         SELF_SHADOWING = true,
         SELF_HEATING   = true,
         SOLVER         = AsteroidThermoPhysicalModels.ForwardEulerSolver(thermo_params),


### PR DESCRIPTION
Rename abstract types:
- `ThermoPhysicalModel` ->  `AbstractAsteroidThermoPhysicalModel` (alias: `AbstractAsteroidTPM`)

Rename concrete types:
- `SingleTPM` -> `SingleAsteroidThermoPhysicalModel` (alias `SingleAsteroidTPM`)
- `BinaryTPM` -> `BinaryAsteroidThermoPhysicalModel` (alias `BinaryAsteroidTPM`)
- `SingleTPMResult` -> `SingleAsteroidThermoPhysicalModelResult` (alias `SingleAsteroidTPMResult`)
- `BinaryTPMResult` -> `BinaryAsteroidThermoPhysicalModelResult` (alias `BinaryAsteroidTPMResult`)