### PR TITLE
Update AsteroidShapeModels to v0.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Aqua = "0.8"
-AsteroidShapeModels = "0.1.0"
+AsteroidShapeModels = "0.2.0"
 CSV = "0"
 DataFrames = "1"
 Downloads = "1"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ Temperature distribution of asteroid Didymos and its satellite Dimorphos:
 ## 📖 Basic Usage
 
 ```julia
+using AsteroidShapeModels
 using AsteroidThermoPhysicalModels
+
 
 # Load shape model
 shape = load_shape_obj("asteroid_shape.obj"; scale=1000, find_visible_facets=true)

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -9,6 +9,7 @@ For more detailed examples, please refer to the [Astroshaper-examples](https://g
 This example demonstrates how to set up and run a thermophysical model for asteroid Ryugu using SPICE kernels for ephemerides.
 
 ```julia
+using AsteroidShapeModels
 using AsteroidThermoPhysicalModels
 using Downloads
 using LinearAlgebra
@@ -71,7 +72,7 @@ SPICE.kclear()
 ##= Load obj file =##
 path_obj = joinpath("shape", "SHAPE_SFM_49k_v20180804.obj")
     
-shape = AsteroidThermoPhysicalModels.load_shape_obj(path_obj; scale=1000, find_visible_facets=true)
+shape = load_shape_obj(path_obj; scale=1000, find_visible_facets=true)
 n_face = length(shape.faces)  # Number of faces
 
 ##= Thermal properties =##
@@ -115,6 +116,7 @@ AsteroidThermoPhysicalModels.export_TPM_results("path/to/save", result)
 This example demonstrates how to set up and run a thermophysical model for the binary asteroid system Didymos-Dimorphos using SPICE kernels for ephemerides.
 
 ```julia
+using AsteroidShapeModels
 using AsteroidThermoPhysicalModels
 using Downloads
 using LinearAlgebra
@@ -194,8 +196,8 @@ SPICE.kclear()
 path_shape1_obj = joinpath("shape", "g_50677mm_rad_obj_didy_0000n00000_v001.obj")
 path_shape2_obj = joinpath("shape", "g_08438mm_lgt_obj_dimo_0000n00000_v002.obj")
     
-shape1 = AsteroidThermoPhysicalModels.load_shape_obj(path_shape1_obj; scale=1000, find_visible_facets=true)
-shape2 = AsteroidThermoPhysicalModels.load_shape_obj(path_shape2_obj; scale=1000, find_visible_facets=true)
+shape1 = load_shape_obj(path_shape1_obj; scale=1000, find_visible_facets=true)
+shape2 = load_shape_obj(path_shape2_obj; scale=1000, find_visible_facets=true)
 
 n_face_shape1 = length(shape1.faces)  # Number of faces of Didymos
 n_face_shape2 = length(shape2.faces)  # Number of faces of Dimorphos

--- a/src/AsteroidThermoPhysicalModels.jl
+++ b/src/AsteroidThermoPhysicalModels.jl
@@ -38,13 +38,6 @@ const au2m = 149597870700    # 1 astronomical unit [m]
                              # IAU 2012 definition (exact)
 const m2au = 1/au2m          # Conversion factor: meters to au
 
-# Re-export types and functions from AsteroidShapeModels.jl
-export ShapeModel, VisibleFacet
-export load_shape_obj, load_shape_grid
-export face_center, face_normal, face_area
-export polyhedron_volume, equivalent_radius, maximum_radius, minimum_radius
-export view_factor, raycast, find_visiblefacets!, isilluminated
-
 include("thermo_params.jl")
 include("TPM.jl")
 

--- a/src/energy_flux.jl
+++ b/src/energy_flux.jl
@@ -424,7 +424,8 @@ function mutual_shadowing!(btpm::BinaryAsteroidTPM, r☉, rₛ, R₂₁)
                 
                     ## if △A₁B₁C₁ and △A₂B₂C₂ are facing each other
                     if d₁₂ ⋅ n̂₁ > 0 && d₁₂ ⋅ n̂₂ < 0
-                        if raycast(A₂, B₂, C₂, r̂☉, G₁)
+                        ray = Ray(G₁, r̂☉)
+                        if intersect_ray_triangle(ray, A₂, B₂, C₂).hit
                             btpm.pri.flux_sun[i] = 0
                             break
                         end
@@ -477,7 +478,8 @@ function mutual_shadowing!(btpm::BinaryAsteroidTPM, r☉, rₛ, R₂₁)
                 
                     ## if △A₁B₁C₁ and △A₂B₂C₂ are facing each other
                     if d₁₂ ⋅ n̂₁ > 0 && d₁₂ ⋅ n̂₂ < 0
-                        if raycast(A₁, B₁, C₁, r̂☉, G₂)
+                        ray = Ray(G₂, r̂☉)
+                        if intersect_ray_triangle(ray, A₁, B₁, C₁).hit
                             btpm.sec.flux_sun[j] = 0
                             break
                         end

--- a/test/TPM_Didymos/TPM_Didymos.jl
+++ b/test/TPM_Didymos/TPM_Didymos.jl
@@ -93,8 +93,8 @@ See https://github.com/Astroshaper/Astroshaper-examples/tree/main/TPM_Didymos fo
     path_shape1_obj = joinpath("shape", "g_50677mm_rad_obj_didy_0000n00000_v001.obj")
     path_shape2_obj = joinpath("shape", "g_08438mm_lgt_obj_dimo_0000n00000_v002.obj")
     
-    shape1 = AsteroidThermoPhysicalModels.load_shape_obj(path_shape1_obj; scale=1000, find_visible_facets=true)
-    shape2 = AsteroidThermoPhysicalModels.load_shape_obj(path_shape2_obj; scale=1000, find_visible_facets=true)
+    shape1 = load_shape_obj(path_shape1_obj; scale=1000, find_visible_facets=true)
+    shape2 = load_shape_obj(path_shape2_obj; scale=1000, find_visible_facets=true)
 
     n_face_shape1 = length(shape1.faces)  # Number of faces of Didymos
     n_face_shape2 = length(shape2.faces)  # Number of faces of Dimorphos

--- a/test/TPM_Ryugu/TPM_Ryugu.jl
+++ b/test/TPM_Ryugu/TPM_Ryugu.jl
@@ -77,7 +77,7 @@ See https://github.com/Astroshaper/Astroshaper-examples/tree/main/TPM_Ryugu for 
     path_obj = joinpath("shape", "ryugu_test.obj")  # Small model for test
     # path_obj = joinpath("shape", "SHAPE_SFM_49k_v20180804.obj")
     
-    shape = AsteroidThermoPhysicalModels.load_shape_obj(path_obj; scale=1000, find_visible_facets=true)
+    shape = load_shape_obj(path_obj; scale=1000, find_visible_facets=true)
     n_face = length(shape.faces)  # Number of faces
 
     ## --- Thermal properties ---

--- a/test/TPM_non-uniform_thermoparams/TPM_non-uniform_thermoparams.jl
+++ b/test/TPM_non-uniform_thermoparams/TPM_non-uniform_thermoparams.jl
@@ -77,7 +77,7 @@ Based on TPM_Ryugu test but with varying thermophysical properties.
     path_obj = joinpath("shape", "ryugu_test.obj")  # Small model for test
     # path_obj = joinpath("shape", "SHAPE_SFM_49k_v20180804.obj")
     
-    shape = AsteroidThermoPhysicalModels.load_shape_obj(path_obj; scale=1000, find_visible_facets=true)
+    shape = load_shape_obj(path_obj; scale=1000, find_visible_facets=true)
     n_face = length(shape.faces)  # Number of faces
 
     ## --- Thermal properties ---

--- a/test/TPM_zero-conductivity/TPM_zero-conductivity.jl
+++ b/test/TPM_zero-conductivity/TPM_zero-conductivity.jl
@@ -40,7 +40,7 @@ This test validates:
 
     ## --- Load obj file ---
     path_obj = joinpath("shape", "ryugu_test.obj")
-    shape = AsteroidThermoPhysicalModels.load_shape_obj(path_obj; scale=1000, find_visible_facets=true)
+    shape = load_shape_obj(path_obj; scale=1000, find_visible_facets=true)
     n_face = length(shape.faces)  # Number of faces
 
     ## --- Thermal properties: zero-conductivity case ---

--- a/test/find_visiblefacets.jl
+++ b/test/find_visiblefacets.jl
@@ -19,13 +19,13 @@ This test verifies:
     ## --- Shape model of Ryugu ---
     filepath = joinpath("shape", "ryugu_test.obj")  # Small model for test
     println("========  $(filepath)  ========")
-    shape = AsteroidThermoPhysicalModels.load_shape_obj(filepath; scale=1000, find_visible_facets=true)
+    shape = load_shape_obj(filepath; scale=1000, find_visible_facets=true)
     println(shape)
 
     ## --- Icosahedron ---
     filepath = joinpath("shape", "icosahedron.obj")
     println("========  $(filepath)  ========")
-    shape = AsteroidThermoPhysicalModels.load_shape_obj(filepath; scale=1, find_visible_facets=true)
+    shape = load_shape_obj(filepath; scale=1, find_visible_facets=true)
     println(shape)
 
     println("Number of total visible facets: ", sum(length.(shape.visiblefacets)))  # This should be zero for an icosahedron.

--- a/test/heat_conduction_1D.jl
+++ b/test/heat_conduction_1D.jl
@@ -18,7 +18,7 @@ Tests for 1D heat conduction solvers:
 
     ## --- Shape model ---
     path_obj = joinpath("shape", "single_face.obj")
-    shape = AsteroidThermoPhysicalModels.load_shape_obj(path_obj)
+    shape = load_shape_obj(path_obj)
     n_face = length(shape.faces)  # Number of faces
 
     ## --- Seeting of time step ---

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ This file orchestrates all tests including:
 - Validation against analytical solutions
 =#
 
+using AsteroidShapeModels
 using AsteroidThermoPhysicalModels
 using Test
 using Aqua

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -19,7 +19,7 @@ Validates both upper and lower boundary implementations.
     
     # Shape model (single face)
     path_obj = joinpath(@__DIR__, "shape", "single_face.obj")
-    shape = AsteroidThermoPhysicalModels.load_shape_obj(path_obj)
+    shape = load_shape_obj(path_obj)
     
     # Time settings
     et_range = range(0.0, 0.1; step=1e-4)

--- a/test/thermal_radiation.jl
+++ b/test/thermal_radiation.jl
@@ -30,7 +30,7 @@ This test validates:
 
     ## --- Load shape model ---
     path_obj = joinpath("shape", "fractal_v2572_f5000.obj")
-    shape = AsteroidThermoPhysicalModels.load_shape_obj(path_obj; scale=1, find_visible_facets=true)
+    shape = load_shape_obj(path_obj; scale=1, find_visible_facets=true)
     n_face = length(shape.faces)  # Number of faces
 
     ## --- Ephemerides ---


### PR DESCRIPTION
## Summary
- Updated `AsteroidShapeModels` dependency from v0.1.0 to v0.2.0
- Adapted code to handle breaking changes in the API
- Updated documentation and tests for explicit imports

## Breaking Changes in `AsteroidShapeModels` v0.2.0
The main breaking change is the removal of the `raycast` function, which has been replaced with:
- `Ray` type constructor
- `intersect_ray_triangle` function that returns a result object with a `.hit` property

## Changes Made

### 1. Dependency Update
- Updated `Project.toml` to require AsteroidShapeModels v0.2.0

### 2. API Adaptations
- Replaced `raycast(A, B, C, direction, origin)` calls with:
  ```julia
  ray = Ray(origin, direction)
  if intersect_ray_triangle(ray, A, B, C).hit
  ```
- Removed re-exports of AsteroidShapeModels functions to encourage explicit imports

### 3. Documentation Updates
- Added `using AsteroidShapeModels` to all examples in README and docs
- Updated test files to use explicit imports
- Removed qualified function calls (e.g., `AsteroidThermoPhysicalModels.load_shape_obj` → `load_shape_obj`)

## Test Results
All tests pass successfully with the new version.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>