### PR TITLE
build: Update to `AsteroidShapeModels.jl` v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2025-01-13
+## [Unreleased]
+
+### Changed
+- Updated `AsteroidShapeModels.jl` dependency from v0.4.1 to v0.4.2
+  - Benefit from ~2.5x faster illumination calculations due to face maximum elevation optimization
+  - No code changes required due to backward compatibility
+
+## [0.1.0] - 2025-07-13
 
 ### Added
 - `illuminated_faces` field to `SingleAsteroidThermoPhysicalModel` for batch illumination processing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated `AsteroidShapeModels.jl` dependency from v0.4.1 to v0.4.2
-  - Benefit from ~2.5x faster illumination calculations due to face maximum elevation optimization
+  - Shadow calculations are now 2.7x faster (1.04s → 0.39s for 72 time steps and 49k Ryugu shape)
+  - Overall simulation performance improved by 13.6% for single asteroids (Ryugu: 103s → 89s for 20 rotations, 1440 time steps)
+  - Face maximum elevation optimization automatically applied when using `with_face_visibility=true`
   - No code changes required due to backward compatibility
 
 ## [0.1.0] - 2025-07-13

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Aqua = "0.8"
-AsteroidShapeModels = "0.4.1"
+AsteroidShapeModels = "0.4.2"
 CSV = "0.10"
 DataFrames = "1"
 Downloads = "1"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,10 +65,12 @@ The v0.1.0 release marks a significant milestone with stabilized core APIs, crit
 - Coordinate transformations centralized
 
 ---
+    **↓ Planned Releases ↓**
+---
 
 ## v0.1.1 - Performance and Test Improvements (Target: August 2025)
 
-- [ ] **Update to `AsteroidShapeModels.jl` v0.4.2**
+- [x] **Update to `AsteroidShapeModels.jl` v0.4.2**
   - Illumination evaluation was optimized in v0.4.2, which will lead to ~2.5x faster shadow calculations.
 
 - [ ] **Code organization and refactoring**

--- a/benchmark/Manifest.toml
+++ b/benchmark/Manifest.toml
@@ -47,15 +47,15 @@ version = "1.11.0"
 
 [[deps.AsteroidShapeModels]]
 deps = ["FileIO", "GeometryBasics", "ImplicitBVH", "LinearAlgebra", "MeshIO", "StaticArrays"]
-git-tree-sha1 = "33d07e1e3171642b41147a42ccedb08c488d188b"
+git-tree-sha1 = "4416a34fa0c419c0a9b40dc15b95f89a309fe557"
 uuid = "a7943d8e-5d65-4248-ae23-0082f5115a05"
-version = "0.4.1"
+version = "0.4.2"
 
 [[deps.AsteroidThermoPhysicalModels]]
 deps = ["AsteroidShapeModels", "CSV", "DataFrames", "LinearAlgebra", "ProgressMeter", "StaticArrays", "Statistics"]
 path = ".."
 uuid = "ab46f4a3-3c83-4d86-98d6-41a8b1a2e76e"
-version = "0.0.8-DEV"
+version = "0.1.0"
 
 [[deps.Atomix]]
 deps = ["UnsafeAtomics"]
@@ -534,9 +534,9 @@ version = "1.2.1"
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
-git-tree-sha1 = "0feb6b9031bd5c51f9072393eb5ab3efd31bf9e4"
+git-tree-sha1 = "cbea8a6bd7bed51b1619658dec70035e07b8502f"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.9.13"
+version = "1.9.14"
 
     [deps.StaticArrays.extensions]
     StaticArraysChainRulesCoreExt = "ChainRulesCore"

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -8,31 +8,43 @@ The following benchmarks were performed on Apple M4 (macOS, single-threaded):
 
 ### Single Asteroid (Ryugu)
 - **Shape complexity**: 49,152 faces
-- **1 rotation** (72 time steps): ~5.1 seconds
-- **20 rotations** (1,440 time steps): ~103 seconds (1.7 minutes)
+- **1 rotation** (72 time steps): ~4.8 seconds
+- **20 rotations** (1,440 time steps): ~89 seconds (1.5 minutes)
 - **Memory usage**: 152 KiB (20 rotations), 5.8 KiB (1 rotation)
 - **Allocations**: 20 (20 rotations), 16 (1 rotation)
 - **With shadows and self-heating enabled**
 
 ### Binary System (Didymos-Dimorphos)
 - **Primary**: 1,996 faces, **Secondary**: 3,072 faces (5,068 total)
-- **1 rotation** (72 time steps): ~4.7 seconds (based on Dimorphos' rotation period)
-- **20 rotations** (1,440 time steps): ~89 seconds (1.5 minutes)
-- **Memory usage**: 531 MiB (20 rotations), 28.1 MiB (1 rotation)
-- **Allocations**: 13.4M (20 rotations), 747k (1 rotation)
+- **1 rotation** (72 time steps): ~4.6 seconds (based on Dimorphos' rotation period)
+- **20 rotations** (1,440 time steps): ~94 seconds (1.6 minutes)
+- **Memory usage**: 612 MiB (20 rotations), 30.5 MiB (1 rotation)
+- **Allocations**: 15.6M (20 rotations), 814k (1 rotation)
 - **With mutual shadowing and heating enabled**
 - **Note**: Rotation counts refer to Dimorphos (secondary) rotation periods
 
-### Component Performance (per time step)
-- **Shadow calculations**: ~0.014 seconds (1.0s for 72 steps) - **27x faster with v0.4.1**
-- **Self-heating**: ~0.025 seconds (1.8s for 72 steps)
-- **Temperature update**: ~0.023 seconds (1.6s for 72 steps)
-- **Unified flux calculation**: ~0.040 seconds (2.9s for 72 steps) for Ryugu
-- **Unified flux calculation**: ~0.062 seconds (4.5s for 72 steps) for Didymos
+### Component Performance (72 time steps)
+- **Shadow calculations**: ~0.39 seconds - **2.7x faster with v0.4.2**
+- **Self-heating**: ~1.9 seconds
+- **Temperature update**: ~1.7 seconds
+- **Unified flux calculation**: ~2.3 seconds for Ryugu
+- **Unified flux calculation**: ~4.5 seconds for Didymos
 
-*Note: Component benchmarks show total time for 72 calls in isolation*
+### Time Distribution (Single Asteroid)
+For a typical single rotation simulation:
+- **Flux calculation**: 48.9%
+  - **Shadow overhead**: 8.3%
+  - **Self-heating**: 39.1%
+- **Temperature update**: 36.3%
 
-*Note: Performance may vary depending on CPU architecture. Intel/AMD processors may show different characteristics.*
+
+*Note: Percentages sum to more than 100% as components are measured independently*
+
+### Performance History
+- **v0.4.1 → v0.4.2**: Shadow calculations improved by 2.7x due to face maximum elevation optimization
+- **v0.3.0 → v0.4.1**: Shadow calculations improved by 27x with new illumination API
+
+*Note: Benchmarks performed on 2025-07-21 with AsteroidShapeModels.jl v0.4.2*
 
 ## Performance Considerations
 


### PR DESCRIPTION
## Summary

This PR updates the dependency to `AsteroidShapeModels.jl` v0.4.2, which brings significant performance improvements to shadow calculations.

## Performance Improvements

- **Shadow calculations**: 2.7x faster (1.04s → 0.39s for 72 time steps with 49k Ryugu shape)
- **Overall simulation**: 13.6% faster for single asteroids (Ryugu: 103s → 89s for 20 rotations, 1440 time steps)
- Automatic face maximum elevation optimization when using `with_face_visibility=true`

## Changes

- Update `AsteroidShapeModels.jl` dependency from v0.4.1 to v0.4.2
- Update benchmark environment dependencies
- Document performance improvements in `CHANGELOG.md` and `benchmarks.md`
- Mark v0.1.1 task as completed in `ROADMAP.md`

## Compatibility

No code changes required - v0.4.2 maintains full backward compatibility.

## Benchmarks

Benchmarks performed on 2025-07-21 with Apple M4 (macOS, single-threaded):

### Time Distribution (Single Asteroid)
- Flux calculation: 48.9%
    - Shadow overhead: 8.3% (reduced from ~20%)
    - Self-heating: 39.1%
- Temperature update: 36.3%


### Performance History
- v0.3.0 → v0.4.1: Shadow calculations improved by 27x
- v0.4.1 → v0.4.2: Shadow calculations improved by 2.7x
- **Total improvement**: ~70x faster than v0.3.0

🤖 Generated with [Claude Code](https://claude.ai/code)