### PR TITLE
fix: Update HERA SPICE kernel download URLs to ESAC FTP server

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -68,7 +68,7 @@ function download_benchmark_data()
     ]
     
     for path_kernel in didymos_kernels
-        url_kernel = "https://s2e2.cosmos.esa.int/bitbucket/projects/SPICE_KERNELS/repos/hera/raw/kernels/$(path_kernel)?at=refs%2Ftags%2Fv161_20230929_001"
+        url_kernel = "https://spiftp.esac.esa.int/data/SPICE/HERA/kernels/$(path_kernel)"
         filepath = joinpath("benchmark/kernel", path_kernel)
         mkpath(dirname(filepath))
         if !isfile(filepath)
@@ -76,19 +76,19 @@ function download_benchmark_data()
             Downloads.download(url_kernel, filepath)
         end
     end
-    
+
     # Didymos shape models
     didymos_shapes = [
         "g_50677mm_rad_obj_didy_0000n00000_v001.obj",
         "g_08438mm_lgt_obj_dimo_0000n00000_v002.obj",
     ]
-    
+
     for path_shape in didymos_shapes
-        url_kernel = "https://s2e2.cosmos.esa.int/bitbucket/projects/SPICE_KERNELS/repos/hera/raw/kernels/dsk/$(path_shape)?at=refs%2Ftags%2Fv161_20230929_001"
+        url_shape = "https://spiftp.esac.esa.int/data/SPICE/HERA/kernels/dsk/$(path_shape)"
         filepath = joinpath("benchmark/shape", path_shape)
         if !isfile(filepath)
             @info "Downloading $(path_shape)..."
-            Downloads.download(url_kernel, filepath)
+            Downloads.download(url_shape, filepath)
         end
     end
 end

--- a/test/TPM_Didymos/TPM_Didymos.jl
+++ b/test/TPM_Didymos/TPM_Didymos.jl
@@ -39,7 +39,7 @@ See https://github.com/Astroshaper/Astroshaper-examples/tree/main/TPM_Didymos fo
 
     ## --- Download SPICE kernels ---
     for path_kernel in paths_kernel
-        url_kernel = "https://s2e2.cosmos.esa.int/bitbucket/projects/SPICE_KERNELS/repos/hera/raw/kernels/$(path_kernel)?at=refs%2Ftags%2Fv161_20230929_001"
+        url_kernel = "https://spiftp.esac.esa.int/data/SPICE/HERA/kernels/$(path_kernel)"
         filepath = joinpath("kernel", path_kernel)
         mkpath(dirname(filepath))
         isfile(filepath) || Downloads.download(url_kernel, filepath)
@@ -47,10 +47,10 @@ See https://github.com/Astroshaper/Astroshaper-examples/tree/main/TPM_Didymos fo
 
     ## --- Download shape models ---
     for path_shape in paths_shape
-        url_kernel = "https://s2e2.cosmos.esa.int/bitbucket/projects/SPICE_KERNELS/repos/hera/raw/kernels/dsk/$(path_shape)?at=refs%2Ftags%2Fv161_20230929_001"
+        url_shape = "https://spiftp.esac.esa.int/data/SPICE/HERA/kernels/dsk/$(path_shape)"
         filepath = joinpath("shape", path_shape)
         mkpath(dirname(filepath))
-        isfile(filepath) || Downloads.download(url_kernel, filepath)
+        isfile(filepath) || Downloads.download(url_shape, filepath)
     end
 
     ## --- Load the SPICE kernels ---


### PR DESCRIPTION
## Summary

- Replace defunct ESA BitBucket URLs with new ESAC FTP server URLs for downloading HERA SPICE kernels and Didymos/Dimorphos shape models
- Fix variable name typo in shape model download loop (`url_kernel` → `url_shape`)

## Changes

| File | Change |
|---|---|
| `test/TPM_Didymos/TPM_Didymos.jl` | Update kernel and shape download URLs |
| `benchmark/benchmarks.jl` | Update kernel and shape download URLs |

**Old URL pattern:**
```
https://s2e2.cosmos.esa.int/bitbucket/projects/SPICE_KERNELS/repos/hera/raw/kernels/<path>?at=refs%2Ftags%2Fv161_20230929_001
```

**New URL pattern:**
```
https://spiftp.esac.esa.int/data/SPICE/HERA/kernels/<path>
```

## Background

The ESA BitBucket server (`s2e2.cosmos.esa.int`) is no longer accessible. The same fix was applied in `AsteroidShapeModels.jl` #56. This PR applies the equivalent change to `AsteroidThermoPhysicalModels.jl`.

## Test plan

- [x] Verify that `test/TPM_Didymos/TPM_Didymos.jl` can download HERA kernels from the new URLs
- [ ] Verify that `benchmark/benchmarks.jl` can download Didymos data from the new URLs
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)