### PR TITLE
ci: Update codecov-action from v5 to v7

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
## Summary

Update `codecov/codecov-action` from `v5` to `v7` to fix CI failures affecting all branches.

## Root Cause

Codecov updated their GPG signing key in April 2026. `codecov-action@v5` does not include the new public key, causing all CI runs to fail at the coverage upload step with:

```
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
```

`codecov-action@v7` includes the updated public key and resolves the issue.

## Impact

This failure affects all branches, not just this PR. The Julia tests themselves all pass — only the Codecov upload step fails.

## Test plan

- [x] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)