### PR TITLE
build: Update `AsteroidShapeModels.jl` compat to support v0.5.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Aqua = "0.8"
-AsteroidShapeModels = "0.4.2"
+AsteroidShapeModels = "0.4.2, 0.5"
 CSV = "0.10"
 DataFrames = "1"
 Downloads = "1"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,6 +76,7 @@ The v0.1.0 release marks a significant milestone with stabilized core APIs, crit
 - [ ] **Update to `AsteroidShapeModels.jl` v0.5.x**
   - v0.5.x adds `HierarchicalShapeModel` for surface roughness support and `create_shape_crater`
   - No breaking changes affect this package
+  - Update compat to `"0.4.2, 0.5"` to support both v0.4.x and v0.5.x (v0.4.x support will be dropped in v0.2.0 when `HierarchicalShapeModel` becomes a hard requirement)
   - Remove duplicate geometry functions from `src/roughness.jl` that are now provided by `AsteroidShapeModels.jl`
 
 - [ ] **Code organization and refactoring**


### PR DESCRIPTION
## Summary

- Update `AsteroidShapeModels` compat from `"0.4.2"` to `"0.4.2, 0.5"`
- Document the compat strategy in `ROADMAP.md`

## Background

`AsteroidShapeModels.jl` v0.5.x adds `HierarchicalShapeModel` and `create_shape_crater`, which are the foundation for the surface roughness TPM work planned in v0.2.0. Compatibility with v0.4.x is maintained for this patch release (v0.1.1) to avoid breaking existing users. Support for v0.4.x will be dropped in v0.2.0 when `HierarchicalShapeModel` becomes a hard requirement.

## Test plan

- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)