### PR TITLE
chore: Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-06-08
+
+No migration required from v0.1.0. There are no breaking changes in this release.
+
+### Fixed
+- Updated HERA SPICE kernel download URLs to ESAC FTP server in `test/TPM_Didymos/TPM_Didymos.jl` and `benchmark/benchmarks.jl` (#191)
+  - The ESA BitBucket server now requires authentication, which caused CI to fail when downloading kernels
+
 ### Changed
 - Updated `AsteroidShapeModels.jl` dependency from v0.4.1 to v0.4.2
   - Shadow calculations are now 2.7x faster (1.04s → 0.39s for 72 time steps and 49k Ryugu shape)
   - Overall simulation performance improved by 13.6% for single asteroids (Ryugu: 103s → 89s for 20 rotations, 1440 time steps)
   - Face maximum elevation optimization automatically applied when using `with_face_visibility=true`
   - No code changes required due to backward compatibility
+- Extended `AsteroidShapeModels.jl` compat to `"0.4.2, 0.5"` to support v0.5.x (#194)
+  - v0.5.x adds `HierarchicalShapeModel` and `create_shape_crater`, which are prerequisites for surface roughness support planned in v0.2.0
+  - Compatibility with v0.4.x is maintained; v0.4.x support will be dropped in v0.2.0
+
+### Removed
+- Removed `crater_curvature_radius` and `concave_spherical_segment` from `src/roughness.jl`; these functions are now provided by `AsteroidShapeModels.jl` v0.5.0+ (#192)
+- Removed `test/find_visiblefacets.jl`; the test duplicated coverage already provided by `AsteroidShapeModels.jl` (#195)
+
+### Internal
+- Split `src/TPM.jl` (892 lines) into focused files: `solver_types.jl`, `tpm_types.jl`, `tpm_result.jl`, `tpm_run.jl` (#195)
 
 ## [0.1.0] - 2025-07-13
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AsteroidThermoPhysicalModels"
 uuid = "ab46f4a3-3c83-4d86-98d6-41a8b1a2e76e"
 authors = ["Masanori Kanamaru"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 AsteroidShapeModels = "a7943d8e-5d65-4248-ae23-0082f5115a05"

--- a/README.md
+++ b/README.md
@@ -46,9 +46,16 @@ pkg> add AsteroidThermoPhysicalModels
 - **Yarkovsky Effect**: Orbital perturbation due to asymmetric thermal emission
 - **YORP Effect**: Rotational perturbation due to asymmetric thermal emission
 
-### Coming Soon (v0.2.0)
-- Surface roughness modeling integration with `AsteroidShapeModels.jl`
+### Coming in v0.2.0
+- Surface roughness modeling using `HierarchicalShapeModel` from `AsteroidShapeModels.jl`
 - Enhanced heat conduction solver validation and benchmarks
+
+## 🆕 What's New in v0.1.x
+
+### v0.1.1
+- **Performance**: Shadow calculations are ~2.7x faster via `AsteroidShapeModels.jl` v0.4.2
+- **Compatibility**: Now supports `AsteroidShapeModels.jl` v0.5.x, which introduces `HierarchicalShapeModel` for future surface roughness support
+- **Bug fix**: Updated HERA SPICE kernel download URLs (ESA BitBucket now requires authentication)
 
 ## 🌟 Example
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,19 +68,22 @@ The v0.1.0 release marks a significant milestone with stabilized core APIs, crit
 **↓ Planned Releases ↓**
 ---
 
-## v0.1.1 - Performance and Test Improvements (Target: August 2025)
+## v0.1.1 - Performance and Test Improvements (Released: 2026-06-08)
 
 - [x] **Update to `AsteroidShapeModels.jl` v0.4.2**
   - Illumination evaluation was optimized in v0.4.2, which will lead to ~2.5x faster shadow calculations.
 
-- [ ] **Update to `AsteroidShapeModels.jl` v0.5.x**
+- [x] **Update to `AsteroidShapeModels.jl` v0.5.x**
   - v0.5.x adds `HierarchicalShapeModel` for surface roughness support and `create_shape_crater`
   - No breaking changes affect this package
-  - Update compat to `"0.4.2, 0.5"` to support both v0.4.x and v0.5.x (v0.4.x support will be dropped in v0.2.0 when `HierarchicalShapeModel` becomes a hard requirement)
-  - Remove duplicate geometry functions from `src/roughness.jl` that are now provided by `AsteroidShapeModels.jl`
+  - Updated compat to `"0.4.2, 0.5"` to support both v0.4.x and v0.5.x (v0.4.x support will be dropped in v0.2.0 when `HierarchicalShapeModel` becomes a hard requirement)
+  - Removed duplicate geometry functions from `src/roughness.jl` that are now provided by `AsteroidShapeModels.jl`
 
-- [ ] **Code organization and refactoring**
-  - [ ] Split long files into smaller, more manageable modules
+- [x] **Fix HERA SPICE kernel download URLs**
+  - Updated ESA BitBucket URLs to ESAC FTP server (authentication now required on BitBucket)
+
+- [x] **Code organization**
+  - [x] Split `src/TPM.jl` into focused files: `solver_types.jl`, `tpm_types.jl`, `tpm_result.jl`, `tpm_run.jl`
   - [ ] Refactor long functions for better maintainability (e.g., `implicit_euler!`, `crank_nicolson!`)
 
 - [ ] **mutual_heating! optimization**
@@ -95,7 +98,7 @@ The v0.1.0 release marks a significant milestone with stabilized core APIs, crit
   - [ ] Add comprehensive unit tests for all public functions
   - [ ] Create integration tests for complex workflows
   - [ ] Test edge cases and error conditions
-  - [ ] Remove geometric operation tests that duplicate `AsteroidShapeModels.jl` tests
+  - [x] Remove geometric operation tests that duplicate `AsteroidShapeModels.jl` tests
 
 ## v0.2.0 - Surface Roughness Support (Target: September 2025)
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,6 +19,7 @@ makedocs(;
         "Usage Examples" => "examples.md",
         "Performance" => "benchmarks.md",
         "API Reference" => "api.md",
+        "Migration Guide" => "migration.md",
     ],
 )
 

--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -1,0 +1,60 @@
+# Migration Guide
+
+This page summarizes breaking changes between versions and how to update your code.
+
+---
+
+## v0.1.1
+
+No breaking changes. No migration required from v0.1.0.
+
+**Note:** `AsteroidShapeModels.jl` v0.5.x is now supported. If you upgrade to v0.5.x,
+the geometry functions `crater_curvature_radius` and `concave_spherical_segment` are no
+longer re-exported from this package; use `AsteroidShapeModels` directly instead.
+These functions were not part of the public API of this package, so most users are unaffected.
+
+---
+
+## v0.1.0 (from v0.0.7)
+
+### 1. Visibility API changes (via AsteroidShapeModels.jl)
+
+```julia
+# Old (v0.0.7)
+visible_faces = shape.visiblefacets[face_id]
+
+# New (v0.1.0)
+visible_faces = get_visible_face_indices(shape.face_visibility_graph, face_id)
+view_factors  = get_view_factors(shape.face_visibility_graph, face_id)
+```
+
+### 2. Shape loading
+
+BVH and `face_visibility_graph` are now built automatically when needed by TPM constructors.
+
+```julia
+# Both are now equivalent; no need to pre-build manually
+shape = load_shape_obj("shape.obj"; scale=1000)
+
+# Optional: pre-build for better performance on large models
+shape = load_shape_obj("shape.obj"; scale=1000, with_face_visibility=true, with_bvh=true)
+```
+
+### 3. Binary asteroid flux updates
+
+The multiple-call pattern was replaced by a unified API:
+
+```julia
+# Old (v0.0.7) — multiple calls required
+update_flux_sun!(btpm, r☉₁, r₁₂, R₁₂)
+update_flux_scat_single!(btpm)
+update_flux_rad_single!(btpm)
+mutual_heating!(btpm, r₁₂, R₂₁)
+
+# New (v0.1.0) — unified single call
+update_flux_all!(btpm, r☉₁, r₁₂, R₁₂)
+```
+
+### 4. Minimum Julia version
+
+Raised from 1.6 to 1.10.


### PR DESCRIPTION
## Release v0.1.1

See [CHANGELOG](https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl/blob/release/v0.1.1/CHANGELOG.md#0111---2026-06-08) for details.

### Summary of changes

- **Fixed**: Updated HERA SPICE kernel download URLs to ESAC FTP server (ESA BitBucket now requires authentication)
- **Changed**: Updated `AsteroidShapeModels.jl` dependency to support v0.4.2 and v0.5.x
- **Removed**: Duplicate geometry functions and redundant test now provided by `AsteroidShapeModels.jl`
- **Docs**: Added migration guide page; added What's New section to README

No breaking changes. No migration required from v0.1.0.

## Test plan

- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)