### PR TITLE
refactor: parametric `*Ephemerides{R}` and `*Solution{F}` types, remove `*WithDynamics`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,21 @@ solution = solve(problem, CrankNicolson();
 - **Boundary condition types** (previously flags in `run_TPM!`)
   - `RadiationBoundaryCondition()`, `InsulationBoundaryCondition()`, `IsothermalBoundaryCondition()`
 
-- **Solution types**
-  - `SingleAsteroidThermoPhysicalSolution`: holds simulation output for a single asteroid
-  - `BinaryAsteroidThermoPhysicalSolution`: holds simulation output for a binary asteroid system
+- **Ephemerides types** — inputs for `solve`
+  - `SingleAsteroidEphemerides(times, r_sun)`: temperature-only mode; `r_sun` is the sun position in the body-fixed frame
+  - `SingleAsteroidEphemerides(times, r_sun, R_body_to_inertial)`: force/torque mode; additionally accepts body-to-inertial rotation matrices
+  - `BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary)`: temperature-only mode for binary systems
+  - `BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial)`: force/torque mode for binary systems
+  - The presence or absence of rotation matrices is encoded in the type parameter `{R}` (`R = Nothing` or `R <: AbstractVector`), enabling zero-overhead dispatch in `solve`
+
+- **Solution types** (parametric on `{F}`)
+  - `SingleAsteroidThermoPhysicalSolution{F}`: holds simulation output for a single asteroid
+    - `F = Nothing`: temperature-only mode; `forces` and `torques` fields are `nothing`
+    - `F = Vector{SVector{3,Float64}}`: force/torque mode; net thermal force and torque are stored in the inertial frame
+  - `BinaryAsteroidThermoPhysicalSolution{F}`: holds simulation output for a binary asteroid system; contains `primary` and `secondary` sub-solutions of the same `{F}` type
 
 - `export_solution(dirpath, solution)`: export simulation results to CSV files; replaces `export_TPM_results`
+  - `physical_quantities.csv` includes `force_x/y/z` and `torque_x/y/z` columns when `F <: AbstractVector`
 - `subsolar_temperature(r☉, params)` is now publicly exported
 - `ThermoParams` is now publicly exported (previously required `AsteroidThermoPhysicalModels.ThermoParams`)
 

--- a/src/AsteroidThermoPhysicalModels.jl
+++ b/src/AsteroidThermoPhysicalModels.jl
@@ -42,9 +42,9 @@ const m2au = 1/au2m          # Conversion factor: meters to au
 include("ephem_types.jl")
 export AbstractAsteroidEphemerides
 export AbstractSingleAsteroidEphemerides
-export SingleAsteroidEphemerides, SingleAsteroidEphemeridesWithDynamics
+export SingleAsteroidEphemerides
 export AbstractBinaryAsteroidEphemerides
-export BinaryAsteroidEphemerides, BinaryAsteroidEphemeridesWithDynamics
+export BinaryAsteroidEphemerides
 
 include("thermo_params.jl")
 export ThermoParams

--- a/src/ephem_types.jl
+++ b/src/ephem_types.jl
@@ -7,11 +7,13 @@ These replace the informal NamedTuple previously used as `ephem`.
 Type hierarchy:
     AbstractAsteroidEphemerides
     ├── AbstractSingleAsteroidEphemerides
-    │   ├── SingleAsteroidEphemerides
-    │   └── SingleAsteroidEphemeridesWithDynamics
+    │   └── SingleAsteroidEphemerides{R}
     └── AbstractBinaryAsteroidEphemerides
-        ├── BinaryAsteroidEphemerides
-        └── BinaryAsteroidEphemeridesWithDynamics
+        └── BinaryAsteroidEphemerides{R}
+
+Type parameter R:
+    R = Nothing                          : temperature only (no force/torque)
+    R = Vector{SMatrix{3,3,Float64,9}}   : force/torque output in the inertial frame
 =#
 
 # ╔═══════════════════════════════════════════════════════════════════╗
@@ -51,158 +53,126 @@ Base.length(ephem::AbstractAsteroidEphemerides) = length(ephem.times)
 # ╚═══════════════════════════════════════════════════════════════════╝
 
 """
-    struct SingleAsteroidEphemerides <: AbstractSingleAsteroidEphemerides
+    struct SingleAsteroidEphemerides{R} <: AbstractSingleAsteroidEphemerides
 
 Ephemerides for a single-asteroid thermophysical simulation.
-Only temperature is computed; force and torque are not.
 
-# Fields
-- `times` : Simulation timesteps [s]
-- `r_sun` : Sun position vector in the body-fixed frame [m]
-"""
-struct SingleAsteroidEphemerides <: AbstractSingleAsteroidEphemerides
-    times ::Vector{Float64}
-    r_sun ::Vector{SVector{3, Float64}}
-
-    function SingleAsteroidEphemerides(times, r_sun)
-        length(times) == length(r_sun) || throw(DimensionMismatch(
-            "times ($(length(times))) and r_sun ($(length(r_sun))) must have the same length"
-        ))
-        new(times, r_sun)
-    end
-end
-
-"""
-    struct SingleAsteroidEphemeridesWithDynamics <: AbstractSingleAsteroidEphemerides
-
-Ephemerides for a single-asteroid thermophysical simulation with force and torque output
-in the inertial frame. Requires the body orientation at each timestep.
+The type parameter `R` controls whether force and torque are computed:
+- `R = Nothing`                        : temperature only; `R_body_to_inertial = nothing`
+- `R = Vector{SMatrix{3,3,Float64,9}}` : force and torque are computed in the inertial frame
 
 # Fields
 - `times`              : Simulation timesteps [s]
-- `r_sun`              : Sun position vector in the body-fixed frame [m]
-- `R_body_to_inertial` : Passive rotation matrix from the body-fixed frame to the inertial frame
+- `r_sun`              : Sun position vector in the body-fixed frame at each timestep [m]
+- `R_body_to_inertial` : Passive rotation matrices from body-fixed to inertial frame,
+                         or `nothing` when force/torque are not needed.
+
+# Constructors
+    SingleAsteroidEphemerides(times, r_sun)
+        -> SingleAsteroidEphemerides{Nothing}
+    SingleAsteroidEphemerides(times, r_sun, R_body_to_inertial)
+        -> SingleAsteroidEphemerides{typeof(R_body_to_inertial)}
 """
-struct SingleAsteroidEphemeridesWithDynamics <: AbstractSingleAsteroidEphemerides
+struct SingleAsteroidEphemerides{R} <: AbstractSingleAsteroidEphemerides
     times              ::Vector{Float64}
     r_sun              ::Vector{SVector{3, Float64}}
-    R_body_to_inertial ::Vector{SMatrix{3,3,Float64,9}}
+    R_body_to_inertial ::R
 
-    function SingleAsteroidEphemeridesWithDynamics(times, r_sun, R_body_to_inertial)
+    function SingleAsteroidEphemerides{R}(
+        times              ::AbstractVector,
+        r_sun              ::AbstractVector,
+        R_body_to_inertial ::R,
+    ) where {R}
         n = length(times)
-        length(r_sun)              == n || throw(DimensionMismatch(
+        length(r_sun) == n || throw(DimensionMismatch(
             "r_sun ($(length(r_sun))) and times ($n) must have the same length"
         ))
-        length(R_body_to_inertial) == n || throw(DimensionMismatch(
+        R_body_to_inertial === nothing || length(R_body_to_inertial) == n || throw(DimensionMismatch(
             "R_body_to_inertial ($(length(R_body_to_inertial))) and times ($n) must have the same length"
         ))
-        new(times, r_sun, R_body_to_inertial)
+        new{R}(times, r_sun, R_body_to_inertial)
     end
 end
 
-"""
-    SingleAsteroidEphemeridesWithDynamics(ephem, R_body_to_inertial)
+# Temperature only: R_body_to_inertial = nothing
+SingleAsteroidEphemerides(times, r_sun) =
+    SingleAsteroidEphemerides{Nothing}(times, r_sun, nothing)
 
-Upgrade constructor: extend a `SingleAsteroidEphemerides` with body orientation data.
-"""
-function SingleAsteroidEphemeridesWithDynamics(
-    ephem              ::SingleAsteroidEphemerides,
-    R_body_to_inertial ::Vector{SMatrix{3,3,Float64,9}},
-)
-    SingleAsteroidEphemeridesWithDynamics(ephem.times, ephem.r_sun, R_body_to_inertial)
-end
+# With rotation matrices for force/torque computation
+SingleAsteroidEphemerides(times, r_sun, R_body_to_inertial) =
+    SingleAsteroidEphemerides{typeof(R_body_to_inertial)}(times, r_sun, R_body_to_inertial)
+
 
 # ╔═══════════════════════════════════════════════════════════════════╗
 # ║                     Binary asteroid                               ║
 # ╚═══════════════════════════════════════════════════════════════════╝
 
 """
-    struct BinaryAsteroidEphemerides <: AbstractBinaryAsteroidEphemerides
+    struct BinaryAsteroidEphemerides{R} <: AbstractBinaryAsteroidEphemerides
 
 Ephemerides for a binary-asteroid thermophysical simulation.
-Only temperature is computed; force and torque are not.
+
+The type parameter `R` controls whether force and torque are computed:
+- `R = Nothing`                        : temperature only; `R_primary_to_inertial = nothing`
+- `R = Vector{SMatrix{3,3,Float64,9}}` : force and torque are computed in the inertial frame
+
+The secondary-to-inertial rotation is not stored but can be derived as:
+
+```math
+R_{s2i} = R_{p2i} \\cdot R_{p2s}^{\\top}
+```
 
 # Fields
 - `times`                  : Simulation timesteps [s]
-- `r_sun`                  : Sun position vector in the primary body-fixed frame [m]
-- `r_secondary`            : Secondary position vector in the primary body-fixed frame [m]
-- `R_primary_to_secondary` : Passive rotation matrix from the primary body-fixed frame to the secondary body-fixed frame
+- `r_sun`                  : Sun position vector in the primary body-fixed frame at each timestep [m]
+- `r_secondary`            : Secondary position vector in the primary body-fixed frame at each timestep [m]
+- `R_primary_to_secondary` : Passive rotation matrices from primary body-fixed to secondary body-fixed frame
+- `R_primary_to_inertial`  : Passive rotation matrices from primary body-fixed to inertial frame,
+                             or `nothing` when force/torque are not needed.
+
+# Constructors
+    BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary)
+        -> BinaryAsteroidEphemerides{Nothing}
+    BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial)
+        -> BinaryAsteroidEphemerides{typeof(R_primary_to_inertial)}
 """
-struct BinaryAsteroidEphemerides <: AbstractBinaryAsteroidEphemerides
+struct BinaryAsteroidEphemerides{R} <: AbstractBinaryAsteroidEphemerides
     times                  ::Vector{Float64}
     r_sun                  ::Vector{SVector{3, Float64}}
     r_secondary            ::Vector{SVector{3, Float64}}
     R_primary_to_secondary ::Vector{SMatrix{3,3,Float64,9}}
+    R_primary_to_inertial  ::R
 
-    function BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary)
+    function BinaryAsteroidEphemerides{R}(
+        times                  ::AbstractVector,
+        r_sun                  ::AbstractVector,
+        r_secondary            ::AbstractVector,
+        R_primary_to_secondary ::AbstractVector,
+        R_primary_to_inertial  ::R,
+    ) where {R}
         n = length(times)
-        length(r_sun)                  == n || throw(DimensionMismatch(
+        length(r_sun) == n || throw(DimensionMismatch(
             "r_sun ($(length(r_sun))) and times ($n) must have the same length"
         ))
-        length(r_secondary)            == n || throw(DimensionMismatch(
+        length(r_secondary) == n || throw(DimensionMismatch(
             "r_secondary ($(length(r_secondary))) and times ($n) must have the same length"
         ))
         length(R_primary_to_secondary) == n || throw(DimensionMismatch(
             "R_primary_to_secondary ($(length(R_primary_to_secondary))) and times ($n) must have the same length"
         ))
-        new(times, r_sun, r_secondary, R_primary_to_secondary)
-    end
-end
-
-"""
-    struct BinaryAsteroidEphemeridesWithDynamics <: AbstractBinaryAsteroidEphemerides
-
-Ephemerides for a binary-asteroid thermophysical simulation with force and torque output
-in the inertial frame. Requires the primary body orientation at each timestep.
-
-The secondary-to-inertial rotation can be derived as
-`R_primary_to_inertial[i] * R_primary_to_secondary[i]'` when needed.
-
-# Fields
-- `times`                  : Simulation timesteps [s]
-- `r_sun`                  : Sun position vector in the primary body-fixed frame [m]
-- `r_secondary`            : Secondary position vector in the primary body-fixed frame [m]
-- `R_primary_to_secondary` : Passive rotation matrix from the primary body-fixed frame to the secondary body-fixed frame
-- `R_primary_to_inertial`  : Passive rotation matrix from the primary body-fixed frame to the inertial frame
-"""
-struct BinaryAsteroidEphemeridesWithDynamics <: AbstractBinaryAsteroidEphemerides
-    times                  ::Vector{Float64}
-    r_sun                  ::Vector{SVector{3, Float64}}
-    r_secondary            ::Vector{SVector{3, Float64}}
-    R_primary_to_secondary ::Vector{SMatrix{3,3,Float64,9}}
-    R_primary_to_inertial  ::Vector{SMatrix{3,3,Float64,9}}
-
-    function BinaryAsteroidEphemeridesWithDynamics(
-        times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial,
-    )
-        n = length(times)
-        length(r_sun)                  == n || throw(DimensionMismatch(
-            "r_sun ($(length(r_sun))) and times ($n) must have the same length"
-        ))
-        length(r_secondary)            == n || throw(DimensionMismatch(
-            "r_secondary ($(length(r_secondary))) and times ($n) must have the same length"
-        ))
-        length(R_primary_to_secondary) == n || throw(DimensionMismatch(
-            "R_primary_to_secondary ($(length(R_primary_to_secondary))) and times ($n) must have the same length"
-        ))
-        length(R_primary_to_inertial)  == n || throw(DimensionMismatch(
+        R_primary_to_inertial === nothing || length(R_primary_to_inertial) == n || throw(DimensionMismatch(
             "R_primary_to_inertial ($(length(R_primary_to_inertial))) and times ($n) must have the same length"
         ))
-        new(times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial)
+        new{R}(times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial)
     end
 end
 
-"""
-    BinaryAsteroidEphemeridesWithDynamics(ephem, R_primary_to_inertial)
+# Temperature only: R_primary_to_inertial = nothing
+BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary) =
+    BinaryAsteroidEphemerides{Nothing}(times, r_sun, r_secondary, R_primary_to_secondary, nothing)
 
-Upgrade constructor: extend a `BinaryAsteroidEphemerides` with primary body orientation data.
-"""
-function BinaryAsteroidEphemeridesWithDynamics(
-    ephem                 ::BinaryAsteroidEphemerides,
-    R_primary_to_inertial ::Vector{SMatrix{3,3,Float64,9}},
-)
-    BinaryAsteroidEphemeridesWithDynamics(
-        ephem.times, ephem.r_sun, ephem.r_secondary, ephem.R_primary_to_secondary,
-        R_primary_to_inertial,
+# With rotation matrices for force/torque computation
+BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial) =
+    BinaryAsteroidEphemerides{typeof(R_primary_to_inertial)}(
+        times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial,
     )
-end

--- a/src/ephem_types.jl
+++ b/src/ephem_types.jl
@@ -73,7 +73,7 @@ The type parameter `R` controls whether force and torque are computed:
     SingleAsteroidEphemerides(times, r_sun, R_body_to_inertial)
         -> SingleAsteroidEphemerides{typeof(R_body_to_inertial)}
 """
-struct SingleAsteroidEphemerides{R} <: AbstractSingleAsteroidEphemerides
+struct SingleAsteroidEphemerides{R <: Union{Nothing, AbstractVector}} <: AbstractSingleAsteroidEphemerides
     times              ::Vector{Float64}
     r_sun              ::Vector{SVector{3, Float64}}
     R_body_to_inertial ::R
@@ -82,7 +82,7 @@ struct SingleAsteroidEphemerides{R} <: AbstractSingleAsteroidEphemerides
         times              ::AbstractVector,
         r_sun              ::AbstractVector,
         R_body_to_inertial ::R,
-    ) where {R}
+    ) where {R <: Union{Nothing, AbstractVector}}
         n = length(times)
         length(r_sun) == n || throw(DimensionMismatch(
             "r_sun ($(length(r_sun))) and times ($n) must have the same length"
@@ -136,7 +136,7 @@ R_{s2i} = R_{p2i} \\cdot R_{p2s}^{\\top}
     BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial)
         -> BinaryAsteroidEphemerides{typeof(R_primary_to_inertial)}
 """
-struct BinaryAsteroidEphemerides{R} <: AbstractBinaryAsteroidEphemerides
+struct BinaryAsteroidEphemerides{R <: Union{Nothing, AbstractVector}} <: AbstractBinaryAsteroidEphemerides
     times                  ::Vector{Float64}
     r_sun                  ::Vector{SVector{3, Float64}}
     r_secondary            ::Vector{SVector{3, Float64}}
@@ -149,7 +149,7 @@ struct BinaryAsteroidEphemerides{R} <: AbstractBinaryAsteroidEphemerides
         r_secondary            ::AbstractVector,
         R_primary_to_secondary ::AbstractVector,
         R_primary_to_inertial  ::R,
-    ) where {R}
+    ) where {R <: Union{Nothing, AbstractVector}}
         n = length(times)
         length(r_sun) == n || throw(DimensionMismatch(
             "r_sun ($(length(r_sun))) and times ($n) must have the same length"

--- a/src/tpm_solution.jl
+++ b/src/tpm_solution.jl
@@ -247,11 +247,11 @@ function record_timestep!(
     solution ::BinaryAsteroidThermoPhysicalSolution{<:AbstractVector},
     state    ::BinaryAsteroidThermoPhysicalState,
     i_time   ::Integer,
-    R_p2i    ::SMatrix{3,3,Float64,9},
-    R_s2i    ::SMatrix{3,3,Float64,9},
+    R₁ᵢ      ::SMatrix{3,3,Float64,9},
+    R₂ᵢ      ::SMatrix{3,3,Float64,9},
 )
-    record_timestep!(solution.primary,   state.primary,   i_time, R_p2i)
-    record_timestep!(solution.secondary, state.secondary, i_time, R_s2i)
+    record_timestep!(solution.primary,   state.primary,   i_time, R₁ᵢ)
+    record_timestep!(solution.secondary, state.secondary, i_time, R₂ᵢ)
 end
 
 

--- a/src/tpm_solution.jl
+++ b/src/tpm_solution.jl
@@ -2,44 +2,46 @@
 tpm_solution.jl
 
 Solution types and export functions for thermophysical simulations.
+
+Type parameter F mirrors the ephem type parameter R:
+    F = Nothing                        : forces/torques not computed (temperature only)
+    F = Vector{SVector{3, Float64}}    : forces/torques stored in the inertial frame
 =#
 
 # ╔═══════════════════════════════════════════════════════════════════╗
-# ║                     Output data format                            ║
+# ║                     Solution types                                ║
 # ╚═══════════════════════════════════════════════════════════════════╝
 
 """
-    struct SingleAsteroidThermoPhysicalSolution
+    struct SingleAsteroidThermoPhysicalSolution{F}
 
 Solution data for a single asteroid thermophysical simulation.
 
-# Fields
-## Saved at all time steps
-- `times`  : Timesteps, given the same vector as `ephem.times` [s]
-- `E_in`   : Input energy per second on the whole surface [W]
-- `E_out`  : Output energy per second from the whole surface [W]
-- `force`  : Thermal force on the asteroid [N]
-- `torque` : Thermal torque on the asteroid [N ⋅ m]
+The type parameter `F` mirrors `SingleAsteroidEphemerides{R}`:
+- `F = Nothing`                     : force/torque not computed; `forces = torques = nothing`
+- `F = Vector{SVector{3, Float64}}` : force/torque stored in the inertial frame
 
-## Saved only at the time steps desired by the user
-- `times_to_save`          : Timesteps to save temperature and thermal force on every face [s]
-- `depth_nodes`            : Depths of the calculation nodes for 1-D heat conduction [m], a vector of size `n_depth`
-- `surface_temperature`    : Surface temperature [K], a matrix in size of `(n_face, n_time)`.
-    - `n_face` : Number of faces
-    - `n_time` : Number of time steps to save surface temperature
-- `subsurface_temperature` : Temperature [K] as a function of depth [m] and time [s], `Dict` with face ID as key and a matrix `(n_depth, n_time)` as an entry.
-    - `n_depth` : The number of the depth nodes
-    - `n_time` : The number of time steps to save temperature
-- `face_forces`            : Thermal force on every face of the shape model [N], a matrix in size of `(n_face, n_time)`.
-    - `n_face` : Number of faces
-    - `n_time` : Number of time steps to save surface temperature
+# Fields
+## Saved at all timesteps
+- `times`   : Timesteps [s]
+- `E_in`    : Input power on the whole surface [W]
+- `E_out`   : Output power from the whole surface [W]
+- `forces`  : Net thermal force in the inertial frame [N], or `nothing`
+- `torques` : Net thermal torque in the inertial frame [N⋅m], or `nothing`
+
+## Saved only at timesteps requested via `times_to_save`
+- `times_to_save`          : Timesteps at which detailed data are saved [s]
+- `depth_nodes`            : Depth of each calculation node [m], size `(n_depth,)`
+- `surface_temperature`    : Surface temperature [K], size `(n_face, n_time)`
+- `subsurface_temperature` : Subsurface temperature [K] by face ID; each entry is `(n_depth, n_time)`
+- `face_forces`            : Per-face thermal force in the body-fixed frame [N], size `(n_face, n_time)`
 """
-struct SingleAsteroidThermoPhysicalSolution
-    times  ::Vector{Float64}
-    E_in   ::Vector{Float64}
-    E_out  ::Vector{Float64}
-    force  ::Vector{SVector{3, Float64}}
-    torque ::Vector{SVector{3, Float64}}
+struct SingleAsteroidThermoPhysicalSolution{F <: Union{Nothing, AbstractVector}}
+    times   ::Vector{Float64}
+    E_in    ::Vector{Float64}
+    E_out   ::Vector{Float64}
+    forces  ::F
+    torques ::F
 
     times_to_save          ::Vector{Float64}
     depth_nodes            ::Vector{Float64}
@@ -50,239 +52,308 @@ end
 
 
 """
-Outer constructor of `SingleAsteroidThermoPhysicalSolution`
-
-# Arguments
-- `state`         : Thermophysical simulation state for a single asteroid
-- `ephem`         : Ephemerides
-- `times_to_save` : Timesteps to save temperature
-- `face_ID`       : Face indices to save subsurface temperature
-"""
-function SingleAsteroidThermoPhysicalSolution(state::SingleAsteroidThermoPhysicalState, ephem, times_to_save::Vector{Float64}, face_ID::Vector{Int})
-    n_step = length(ephem.times)            # Number of time steps
-    n_step_to_save = length(times_to_save)  # Number of time steps to save temperature
-    n_face = length(state.problem.shape.faces)       # Number of faces of the shape model
-
-    E_in   = zeros(n_step)
-    E_out  = zeros(n_step)
-    force  = zeros(SVector{3, Float64}, n_step)
-    torque = zeros(SVector{3, Float64}, n_step)
-
-    depth_nodes = state.problem.thermo_params.Δz * (0:state.problem.thermo_params.n_depth-1)
-    surface_temperature = zeros(n_face, n_step_to_save)
-    subsurface_temperature = Dict{Int,Matrix{Float64}}(
-        i => zeros(state.problem.thermo_params.n_depth, n_step_to_save) for i in face_ID
-    )
-    face_forces = zeros(SVector{3, Float64}, n_face, n_step_to_save)
-
-    return SingleAsteroidThermoPhysicalSolution(
-        ephem.times,
-        E_in,
-        E_out,
-        force,
-        torque,
-        times_to_save,
-        depth_nodes,
-        surface_temperature,
-        subsurface_temperature,
-        face_forces,
-    )
-end
-
-
-"""
-    struct BinaryAsteroidThermoPhysicalSolution
+    struct BinaryAsteroidThermoPhysicalSolution{F}
 
 Solution data for a binary asteroid thermophysical simulation.
 
 # Fields
-- `primary`   : Solution for the primary
-- `secondary` : Solution for the secondary
+- `primary`   : Solution for the primary body
+- `secondary` : Solution for the secondary body
 """
-struct BinaryAsteroidThermoPhysicalSolution
-    primary  ::SingleAsteroidThermoPhysicalSolution
-    secondary::SingleAsteroidThermoPhysicalSolution
+struct BinaryAsteroidThermoPhysicalSolution{F <: Union{Nothing, AbstractVector}}
+    primary   ::SingleAsteroidThermoPhysicalSolution{F}
+    secondary ::SingleAsteroidThermoPhysicalSolution{F}
 end
 
 
-"""
-Outer constructor of `BinaryAsteroidThermoPhysicalSolution`
+# ╔═══════════════════════════════════════════════════════════════════╗
+# ║                     Allocation helpers                            ║
+# ╚═══════════════════════════════════════════════════════════════════╝
 
-# Arguments
-- `state`         : Thermophysical simulation state for a binary asteroid
-- `ephem`         : Ephemerides
-- `times_to_save` : Timesteps to save temperature (Common to both the primary and the secondary)
-- `face_ID_pri`   : Face indices to save subsurface temperature of the primary
-- `face_ID_sec`   : Face indices to save subsurface temperature of the secondary
-"""
-function BinaryAsteroidThermoPhysicalSolution(state::BinaryAsteroidThermoPhysicalState, ephem, times_to_save::Vector{Float64}, face_ID_pri::Vector{Int}, face_ID_sec::Vector{Int})
-    result_primary   = SingleAsteroidThermoPhysicalSolution(state.primary,   ephem, times_to_save, face_ID_pri)
-    result_secondary = SingleAsteroidThermoPhysicalSolution(state.secondary, ephem, times_to_save, face_ID_sec)
+# Allocate a SingleAsteroidThermoPhysicalSolution{Nothing} (temperature only).
+function _alloc_solution_no_force(
+    state         ::SingleAsteroidThermoPhysicalState,
+    times         ::Vector{Float64},
+    times_to_save ::Vector{Float64},
+    face_ID       ::Vector{Int},
+)
+    n_step         = length(times)
+    n_step_to_save = length(times_to_save)
+    n_face         = length(state.problem.shape.faces)
+    n_depth        = state.problem.thermo_params.n_depth
 
-    return BinaryAsteroidThermoPhysicalSolution(result_primary, result_secondary)
+    E_in  = zeros(n_step)
+    E_out = zeros(n_step)
+    depth_nodes            = state.problem.thermo_params.Δz * collect(0:n_depth-1)
+    surface_temperature    = zeros(n_face, n_step_to_save)
+    subsurface_temperature = Dict{Int,Matrix{Float64}}(
+        i => zeros(n_depth, n_step_to_save) for i in face_ID
+    )
+    face_forces = zeros(SVector{3, Float64}, n_face, n_step_to_save)
+
+    SingleAsteroidThermoPhysicalSolution{Nothing}(
+        times, E_in, E_out, nothing, nothing,
+        times_to_save, depth_nodes, surface_temperature, subsurface_temperature, face_forces,
+    )
+end
+
+# Allocate a SingleAsteroidThermoPhysicalSolution{Vector{SVector{3,Float64}}} (with force/torque).
+function _alloc_solution_with_force(
+    state         ::SingleAsteroidThermoPhysicalState,
+    times         ::Vector{Float64},
+    times_to_save ::Vector{Float64},
+    face_ID       ::Vector{Int},
+)
+    n_step         = length(times)
+    n_step_to_save = length(times_to_save)
+    n_face         = length(state.problem.shape.faces)
+    n_depth        = state.problem.thermo_params.n_depth
+
+    E_in    = zeros(n_step)
+    E_out   = zeros(n_step)
+    forces  = zeros(SVector{3, Float64}, n_step)
+    torques = zeros(SVector{3, Float64}, n_step)
+    depth_nodes            = state.problem.thermo_params.Δz * collect(0:n_depth-1)
+    surface_temperature    = zeros(n_face, n_step_to_save)
+    subsurface_temperature = Dict{Int,Matrix{Float64}}(
+        i => zeros(n_depth, n_step_to_save) for i in face_ID
+    )
+    face_forces = zeros(SVector{3, Float64}, n_face, n_step_to_save)
+
+    SingleAsteroidThermoPhysicalSolution{Vector{SVector{3,Float64}}}(
+        times, E_in, E_out, forces, torques,
+        times_to_save, depth_nodes, surface_temperature, subsurface_temperature, face_forces,
+    )
 end
 
 
+# ╔═══════════════════════════════════════════════════════════════════╗
+# ║                     Outer constructors                            ║
+# ╚═══════════════════════════════════════════════════════════════════╝
+
 """
-    record_timestep!(solution::SingleAsteroidThermoPhysicalSolution, state::SingleAsteroidThermoPhysicalState, i_time::Integer)
+    SingleAsteroidThermoPhysicalSolution(state, ephem, times_to_save, face_ID)
 
-Record the simulation state at time step `i_time` into `solution`.
-
-# Arguments
-- `solution` : Solution object for a single asteroid
-- `state`    : Simulation state for a single asteroid
-- `i_time`   : Time step to save data
+Allocate a solution matching the type parameter of `ephem`.
 """
-function record_timestep!(solution::SingleAsteroidThermoPhysicalSolution, state::SingleAsteroidThermoPhysicalState, i_time::Integer)
-    solution.E_in[i_time]   = energy_in(state)
-    solution.E_out[i_time]  = energy_out(state)
-    solution.force[i_time]  = state.force
-    solution.torque[i_time] = state.torque
+SingleAsteroidThermoPhysicalSolution(
+    state         ::SingleAsteroidThermoPhysicalState,
+    ephem         ::SingleAsteroidEphemerides{Nothing},
+    times_to_save ::Vector{Float64},
+    face_ID       ::Vector{Int},
+) = _alloc_solution_no_force(state, ephem.times, times_to_save, face_ID)
 
+SingleAsteroidThermoPhysicalSolution(
+    state         ::SingleAsteroidThermoPhysicalState,
+    ephem         ::SingleAsteroidEphemerides{<:AbstractVector},
+    times_to_save ::Vector{Float64},
+    face_ID       ::Vector{Int},
+) = _alloc_solution_with_force(state, ephem.times, times_to_save, face_ID)
+
+"""
+    BinaryAsteroidThermoPhysicalSolution(state, ephem, times_to_save, face_ID_pri, face_ID_sec)
+
+Allocate a binary solution matching the type parameter of `ephem`.
+"""
+BinaryAsteroidThermoPhysicalSolution(
+    state         ::BinaryAsteroidThermoPhysicalState,
+    ephem         ::BinaryAsteroidEphemerides{Nothing},
+    times_to_save ::Vector{Float64},
+    face_ID_pri   ::Vector{Int},
+    face_ID_sec   ::Vector{Int},
+) = BinaryAsteroidThermoPhysicalSolution{Nothing}(
+    _alloc_solution_no_force(state.primary,   ephem.times, times_to_save, face_ID_pri),
+    _alloc_solution_no_force(state.secondary, ephem.times, times_to_save, face_ID_sec),
+)
+
+BinaryAsteroidThermoPhysicalSolution(
+    state         ::BinaryAsteroidThermoPhysicalState,
+    ephem         ::BinaryAsteroidEphemerides{<:AbstractVector},
+    times_to_save ::Vector{Float64},
+    face_ID_pri   ::Vector{Int},
+    face_ID_sec   ::Vector{Int},
+) = BinaryAsteroidThermoPhysicalSolution{Vector{SVector{3,Float64}}}(
+    _alloc_solution_with_force(state.primary,   ephem.times, times_to_save, face_ID_pri),
+    _alloc_solution_with_force(state.secondary, ephem.times, times_to_save, face_ID_sec),
+)
+
+
+# ╔═══════════════════════════════════════════════════════════════════╗
+# ║                     record_timestep!                              ║
+# ╚═══════════════════════════════════════════════════════════════════╝
+
+# Shared helper: record temperature data at times_to_save.
+function _record_temperature!(solution::SingleAsteroidThermoPhysicalSolution, state::SingleAsteroidThermoPhysicalState, i_time::Integer)
     t = solution.times[i_time]
+    t in solution.times_to_save || return
 
-    if t in solution.times_to_save
-        i_time_save = findfirst(isequal(t), solution.times_to_save)
-
-        solution.surface_temperature[:, i_time_save] .= surface_temperature(state)
-
-        for (i, temperature) in solution.subsurface_temperature
-            temperature[:, i_time_save] .= state.temperature[:, i]
-        end
-
-        solution.face_forces[:, i_time_save] .= state.face_forces
+    i_save = findfirst(isequal(t), solution.times_to_save)
+    solution.surface_temperature[:, i_save] .= surface_temperature(state)
+    for (i, T_sub) in solution.subsurface_temperature
+        T_sub[:, i_save] .= state.temperature[:, i]
     end
+    solution.face_forces[:, i_save] .= state.face_forces
 end
 
+"""
+    record_timestep!(solution::SingleAsteroidThermoPhysicalSolution{Nothing}, state, i_time)
+
+Record energy balance and temperature data (no force/torque).
+"""
+function record_timestep!(
+    solution ::SingleAsteroidThermoPhysicalSolution{Nothing},
+    state    ::SingleAsteroidThermoPhysicalState,
+    i_time   ::Integer,
+)
+    solution.E_in[i_time]  = energy_in(state)
+    solution.E_out[i_time] = energy_out(state)
+    _record_temperature!(solution, state, i_time)
+end
 
 """
-    record_timestep!(solution::BinaryAsteroidThermoPhysicalSolution, state::BinaryAsteroidThermoPhysicalState, i_time::Integer)
+    record_timestep!(solution::SingleAsteroidThermoPhysicalSolution{<:AbstractVector}, state, i_time, R)
 
-Record the simulation state at time step `i_time` into `solution`.
-
-# Arguments
-- `solution` : Solution object for a binary asteroid
-- `state`    : Simulation state for a binary asteroid
-- `i_time`   : Time step
+Record energy balance, temperature data, and force/torque rotated to the inertial frame via `R`.
 """
-function record_timestep!(solution::BinaryAsteroidThermoPhysicalSolution, state::BinaryAsteroidThermoPhysicalState, i_time::Integer)
+function record_timestep!(
+    solution ::SingleAsteroidThermoPhysicalSolution{<:AbstractVector},
+    state    ::SingleAsteroidThermoPhysicalState,
+    i_time   ::Integer,
+    R        ::SMatrix{3,3,Float64,9},
+)
+    solution.E_in[i_time]    = energy_in(state)
+    solution.E_out[i_time]   = energy_out(state)
+    solution.forces[i_time]  = R * state.force
+    solution.torques[i_time] = R * state.torque
+    _record_temperature!(solution, state, i_time)
+end
+
+"""
+    record_timestep!(solution::BinaryAsteroidThermoPhysicalSolution{Nothing}, state, i_time)
+"""
+function record_timestep!(
+    solution ::BinaryAsteroidThermoPhysicalSolution{Nothing},
+    state    ::BinaryAsteroidThermoPhysicalState,
+    i_time   ::Integer,
+)
     record_timestep!(solution.primary,   state.primary,   i_time)
     record_timestep!(solution.secondary, state.secondary, i_time)
 end
 
-
 """
-    export_solution(dirpath, result::SingleAsteroidThermoPhysicalSolution)
-
-Export the result of `SingleAsteroidThermoPhysicalState` to CSV files.
-The output files are saved in the following directory structure:
-
-    dirpath
-    ├── physical_quantities.csv
-    ├── subsurface_temperature.csv
-    ├── surface_temperature.csv
-    └── thermal_force.csv
-
-# Arguments
-- `dirpath` : Path to the directory to save CSV files.
-- `solution` : Solution object for a single asteroid
+    record_timestep!(solution::BinaryAsteroidThermoPhysicalSolution{<:AbstractVector}, state, i_time, R_p2i, R_s2i)
 """
-function export_solution(dirpath, result::SingleAsteroidThermoPhysicalSolution)
+function record_timestep!(
+    solution ::BinaryAsteroidThermoPhysicalSolution{<:AbstractVector},
+    state    ::BinaryAsteroidThermoPhysicalState,
+    i_time   ::Integer,
+    R_p2i    ::SMatrix{3,3,Float64,9},
+    R_s2i    ::SMatrix{3,3,Float64,9},
+)
+    record_timestep!(solution.primary,   state.primary,   i_time, R_p2i)
+    record_timestep!(solution.secondary, state.secondary, i_time, R_s2i)
+end
 
-    df = DataFrame()
-    df.time     = result.times
-    df.E_in     = result.E_in
-    df.E_out    = result.E_out
-    df.force_x  = [f[1] for f in result.force]
-    df.force_y  = [f[2] for f in result.force]
-    df.force_z  = [f[3] for f in result.force]
-    df.torque_x = [τ[1] for τ in result.torque]
-    df.torque_y = [τ[2] for τ in result.torque]
-    df.torque_z = [τ[3] for τ in result.torque]
 
-    CSV.write(joinpath(dirpath, "physical_quantities.csv"), df)
+# ╔═══════════════════════════════════════════════════════════════════╗
+# ║                     export_solution                               ║
+# ╚═══════════════════════════════════════════════════════════════════╝
 
-    ##= Surface temperature =##
-    filepath = joinpath(dirpath, "surface_temperature.csv")
+# Shared helpers for non-force CSV outputs.
+function _export_surface_temperature(dirpath, result::SingleAsteroidThermoPhysicalSolution)
     df = hcat(
         DataFrame(time = result.times_to_save),
         DataFrame(
             result.surface_temperature',
-            ["face_$(i)" for i in 1:size(result.surface_temperature, 1)]
+            ["face_$(i)" for i in 1:size(result.surface_temperature, 1)],
         ),
     )
+    CSV.write(joinpath(dirpath, "surface_temperature.csv"), df)
+end
 
-    CSV.write(filepath, df)
-
-    ##= Subsurface temperature =##
-    filepath = joinpath(dirpath, "subsurface_temperature.csv")
-
+function _export_subsurface_temperature(dirpath, result::SingleAsteroidThermoPhysicalSolution)
     nrows = length(result.depth_nodes) * length(result.times_to_save)
     df = DataFrame(
         time  = reshape([t for _ in result.depth_nodes, t in result.times_to_save], nrows),
         depth = reshape([d for d in result.depth_nodes, _ in result.times_to_save], nrows),
     )
-
-    # Add a column for each face
-    for (i, subsurface_temperature) in collect(result.subsurface_temperature)
-        df[:, "face_$(i)"] =
-            reshape(subsurface_temperature, length(subsurface_temperature))
+    for (i, T_sub) in collect(result.subsurface_temperature)
+        df[:, "face_$(i)"] = reshape(T_sub, length(T_sub))
     end
-
-    # Sort the columns by the face ID
     keys_sorted = sort(names(df[:, 3:end]), by=x->parse(Int, replace(x, r"[^0-9]" => "")))
     df = df[:, ["time", "depth", keys_sorted...]]
+    CSV.write(joinpath(dirpath, "subsurface_temperature.csv"), df)
+end
 
-    CSV.write(filepath, df)
-
-    ##= Thermal force on every face of the shape model =##
-    filepath = joinpath(dirpath, "thermal_force.csv")
-
-    n_face = size(result.face_forces, 1)  # Number of faces of the shape model
-    n_step = size(result.face_forces, 2)  # Number of time steps to save temperature
-    nrows = n_face * n_step
-
+function _export_thermal_force(dirpath, result::SingleAsteroidThermoPhysicalSolution)
+    n_face = size(result.face_forces, 1)
+    n_step = size(result.face_forces, 2)
+    nrows  = n_face * n_step
     df = DataFrame(
         time = reshape([t for _ in 1:n_face, t in result.times_to_save], nrows),
         face = reshape([i for i in 1:n_face, _ in result.times_to_save], nrows),
     )
-    df.x = reshape([f[1] for f in result.face_forces], nrows)  # x-component of the thermal force
-    df.y = reshape([f[2] for f in result.face_forces], nrows)  # y-component of the thermal force
-    df.z = reshape([f[3] for f in result.face_forces], nrows)  # z-component of the thermal force
-
-    CSV.write(filepath, df)
+    df.x = reshape([f[1] for f in result.face_forces], nrows)
+    df.y = reshape([f[2] for f in result.face_forces], nrows)
+    df.z = reshape([f[3] for f in result.face_forces], nrows)
+    CSV.write(joinpath(dirpath, "thermal_force.csv"), df)
 end
 
 
 """
-    export_solution(dirpath, result::BinaryAsteroidThermoPhysicalSolution)
+    export_solution(dirpath, result::SingleAsteroidThermoPhysicalSolution{Nothing})
 
-Export the result of `BinaryAsteroidThermoPhysicalState` to CSV files.
-The output files are saved in the following directory structure:
+Export temperature results to CSV (no force/torque columns).
+"""
+function export_solution(dirpath, result::SingleAsteroidThermoPhysicalSolution{Nothing})
+    df = DataFrame(
+        time  = result.times,
+        E_in  = result.E_in,
+        E_out = result.E_out,
+    )
+    CSV.write(joinpath(dirpath, "physical_quantities.csv"), df)
 
-    dirpath
-    ├── primary
-    │   ├── physical_quantities.csv
-    │   ├── subsurface_temperature.csv
-    │   ├── surface_temperature.csv
-    │   └── thermal_force.csv
-    └── secondary
-        ├── physical_quantities.csv
-        ├── subsurface_temperature.csv
-        ├── surface_temperature.csv
-        └── thermal_force.csv
+    _export_surface_temperature(dirpath, result)
+    _export_subsurface_temperature(dirpath, result)
+    _export_thermal_force(dirpath, result)
+end
 
-# Arguments
-- `dirpath`  : Path to the directory to save CSV files.
-- `solution` : Solution object for a binary asteroid
+
+"""
+    export_solution(dirpath, result::SingleAsteroidThermoPhysicalSolution{<:AbstractVector})
+
+Export temperature and force/torque results to CSV.
+"""
+function export_solution(dirpath, result::SingleAsteroidThermoPhysicalSolution{<:AbstractVector})
+    df = DataFrame(
+        time     = result.times,
+        E_in     = result.E_in,
+        E_out    = result.E_out,
+        force_x  = [f[1] for f in result.forces],
+        force_y  = [f[2] for f in result.forces],
+        force_z  = [f[3] for f in result.forces],
+        torque_x = [τ[1] for τ in result.torques],
+        torque_y = [τ[2] for τ in result.torques],
+        torque_z = [τ[3] for τ in result.torques],
+    )
+    CSV.write(joinpath(dirpath, "physical_quantities.csv"), df)
+
+    _export_surface_temperature(dirpath, result)
+    _export_subsurface_temperature(dirpath, result)
+    _export_thermal_force(dirpath, result)
+end
+
+
+"""
+    export_solution(dirpath, solution::BinaryAsteroidThermoPhysicalSolution)
+
+Export results for both bodies to `dirpath/primary/` and `dirpath/secondary/`.
 """
 function export_solution(dirpath, solution::BinaryAsteroidThermoPhysicalSolution)
-    dirpath1 = joinpath(dirpath, "primary")
-    dirpath2 = joinpath(dirpath, "secondary")
-
-    mkpath(dirpath1)
-    mkpath(dirpath2)
-
-    export_solution(dirpath1, solution.primary)
-    export_solution(dirpath2, solution.secondary)
+    dirpath_pri = joinpath(dirpath, "primary")
+    dirpath_sec = joinpath(dirpath, "secondary")
+    mkpath(dirpath_pri)
+    mkpath(dirpath_sec)
+    export_solution(dirpath_pri, solution.primary)
+    export_solution(dirpath_sec, solution.secondary)
 end

--- a/src/tpm_solve.jl
+++ b/src/tpm_solve.jl
@@ -318,12 +318,12 @@ function _solve(
         r☉₁ = ephem.r_sun[i_time]
         r₁₂ = ephem.r_secondary[i_time]
         R₁₂ = ephem.R_primary_to_secondary[i_time]
-        R_p2i = ephem.R_primary_to_inertial[i_time]
-        R_s2i = R_p2i * R₁₂'  # R_secondary_to_inertial = R_p2i * R_primary_to_secondary'
+        R₁ᵢ = ephem.R_primary_to_inertial[i_time]
+        R₂ᵢ = R₁ᵢ * R₁₂'  # R_secondary_to_inertial = R_primary_to_inertial * R_primary_to_secondary'
 
         update_flux_all!(state, r☉₁, r₁₂, R₁₂)
         update_thermal_force!(state)
-        record_timestep!(solution, state, i_time, R_p2i, R_s2i)
+        record_timestep!(solution, state, i_time, R₁ᵢ, R₂ᵢ)
 
         if show_progress
             showvalues = [

--- a/src/tpm_solve.jl
+++ b/src/tpm_solve.jl
@@ -161,7 +161,7 @@ end
 function _solve(
     problem   ::SingleAsteroidThermoPhysicalProblem,
     algorithm ::AbstractThermoPhysicalAlgorithm,
-    ephem     ::SingleAsteroidEphemerides;
+    ephem     ::SingleAsteroidEphemerides{Nothing};
     times_to_save ::Vector{Float64},
     face_ID       ::Vector{Int},
     T₀,
@@ -204,17 +204,51 @@ end
 function _solve(
     problem   ::SingleAsteroidThermoPhysicalProblem,
     algorithm ::AbstractThermoPhysicalAlgorithm,
-    ephem     ::SingleAsteroidEphemeridesWithDynamics;
-    kwargs...,
+    ephem     ::SingleAsteroidEphemerides{<:AbstractVector};
+    times_to_save ::Vector{Float64},
+    face_ID       ::Vector{Int},
+    T₀,
+    show_progress ::Bool,
 )
-    error("solve with SingleAsteroidEphemeridesWithDynamics is not yet implemented")
+    state = _build_single_state(problem, algorithm)
+    init_temperature!(state, T₀)
+
+    solution = SingleAsteroidThermoPhysicalSolution(state, ephem, times_to_save, face_ID)
+
+    if show_progress
+        p = Progress(length(ephem.times); dt=1, desc="Running TPM...", showspeed=true)
+        ProgressMeter.ijulia_behavior(:clear)
+    end
+
+    for i_time in eachindex(ephem.times)
+        r☉ = ephem.r_sun[i_time]
+        R   = ephem.R_body_to_inertial[i_time]
+
+        update_flux_all!(state, r☉)
+        update_thermal_force!(state)
+        record_timestep!(solution, state, i_time, R)
+
+        if show_progress
+            showvalues = [
+                ("Timestep     ", i_time),
+                ("E_out / E_in ", solution.E_out[i_time] / solution.E_in[i_time]),
+            ]
+            ProgressMeter.next!(p; showvalues)
+        end
+
+        i_time == length(ephem.times) && break
+        Δt = ephem.times[i_time+1] - ephem.times[i_time]
+        update_temperature!(state, Δt)
+    end
+
+    return solution
 end
 
 
 function _solve(
     problem   ::BinaryAsteroidThermoPhysicalProblem,
     algorithm ::AbstractThermoPhysicalAlgorithm,
-    ephem     ::BinaryAsteroidEphemerides;
+    ephem     ::BinaryAsteroidEphemerides{Nothing};
     times_to_save ::Vector{Float64},
     face_ID_pri   ::Vector{Int},
     face_ID_sec   ::Vector{Int},
@@ -262,8 +296,48 @@ end
 function _solve(
     problem   ::BinaryAsteroidThermoPhysicalProblem,
     algorithm ::AbstractThermoPhysicalAlgorithm,
-    ephem     ::BinaryAsteroidEphemeridesWithDynamics;
-    kwargs...,
+    ephem     ::BinaryAsteroidEphemerides{<:AbstractVector};
+    times_to_save ::Vector{Float64},
+    face_ID_pri   ::Vector{Int},
+    face_ID_sec   ::Vector{Int},
+    T₀_primary,
+    T₀_secondary,
+    show_progress ::Bool,
 )
-    error("solve with BinaryAsteroidEphemeridesWithDynamics is not yet implemented")
+    state = _build_binary_state(problem, algorithm)
+    init_temperature!(state, T₀_primary, T₀_secondary)
+
+    solution = BinaryAsteroidThermoPhysicalSolution(state, ephem, times_to_save, face_ID_pri, face_ID_sec)
+
+    if show_progress
+        p = Progress(length(ephem.times); dt=1, desc="Running TPM...", showspeed=true)
+        ProgressMeter.ijulia_behavior(:clear)
+    end
+
+    for i_time in eachindex(ephem.times)
+        r☉₁ = ephem.r_sun[i_time]
+        r₁₂ = ephem.r_secondary[i_time]
+        R₁₂ = ephem.R_primary_to_secondary[i_time]
+        R_p2i = ephem.R_primary_to_inertial[i_time]
+        R_s2i = R_p2i * R₁₂'  # R_secondary_to_inertial = R_p2i * R_primary_to_secondary'
+
+        update_flux_all!(state, r☉₁, r₁₂, R₁₂)
+        update_thermal_force!(state)
+        record_timestep!(solution, state, i_time, R_p2i, R_s2i)
+
+        if show_progress
+            showvalues = [
+                ("Timestep                   ", i_time),
+                ("E_out / E_in for primary   ", solution.primary.E_out[i_time] / solution.primary.E_in[i_time]),
+                ("E_out / E_in for secondary ", solution.secondary.E_out[i_time] / solution.secondary.E_in[i_time]),
+            ]
+            ProgressMeter.next!(p; showvalues)
+        end
+
+        i_time == length(ephem.times) && break
+        Δt = ephem.times[i_time+1] - ephem.times[i_time]
+        update_temperature!(state, Δt)
+    end
+
+    return solution
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ using AsteroidShapeModels
 using AsteroidThermoPhysicalModels
 using Test
 using Aqua
+using CSV
 using SPICE
 using Downloads
 using Statistics
@@ -33,3 +34,4 @@ include("heat_conduction_1D.jl")
 include("test_boundary_conditions.jl")
 include("test_ephem_types.jl")
 include("test_problem_api.jl")
+include("test_tpm_with_force.jl")

--- a/test/test_ephem_types.jl
+++ b/test/test_ephem_types.jl
@@ -1,12 +1,13 @@
 #=
 test_ephem_types.jl
 
-Unit tests for *Ephemerides types introduced in v0.2.0:
+Unit tests for parametric *Ephemerides{R} types introduced in v0.2.0:
 - Type hierarchy
-- Construction and field access
+- Construction via convenience constructors
+- Field access
 - Base.length
 - Inner constructor dimension validation
-- Upgrade constructors
+- Explicit parametric construction {Nothing} and {<:AbstractVector}
 =#
 
 @testset "Ephemerides types" begin
@@ -29,9 +30,9 @@ Unit tests for *Ephemerides types introduced in v0.2.0:
 
     @testset "Type hierarchy" begin
         ephem_s  = SingleAsteroidEphemerides(times, r_sun)
-        ephem_sd = SingleAsteroidEphemeridesWithDynamics(times, r_sun, R_body_to_inertial)
+        ephem_sd = SingleAsteroidEphemerides(times, r_sun, R_body_to_inertial)
         ephem_b  = BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary)
-        ephem_bd = BinaryAsteroidEphemeridesWithDynamics(times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial)
+        ephem_bd = BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial)
 
         @test ephem_s  isa AbstractSingleAsteroidEphemerides
         @test ephem_sd isa AbstractSingleAsteroidEphemerides
@@ -42,56 +43,58 @@ Unit tests for *Ephemerides types introduced in v0.2.0:
         @test ephem_sd isa AbstractAsteroidEphemerides
         @test ephem_b  isa AbstractAsteroidEphemerides
         @test ephem_bd isa AbstractAsteroidEphemerides
+
+        # Parametric type parameters
+        @test ephem_s  isa SingleAsteroidEphemerides{Nothing}
+        @test ephem_sd isa SingleAsteroidEphemerides{Vector{SMatrix{3,3,Float64,9}}}
+        @test ephem_b  isa BinaryAsteroidEphemerides{Nothing}
+        @test ephem_bd isa BinaryAsteroidEphemerides{Vector{SMatrix{3,3,Float64,9}}}
     end
 
-    @testset "SingleAsteroidEphemerides" begin
+    @testset "SingleAsteroidEphemerides{Nothing}" begin
         ephem = SingleAsteroidEphemerides(times, r_sun)
 
-        @test ephem.times === times
-        @test ephem.r_sun === r_sun
+        @test ephem.times              === times
+        @test ephem.r_sun              === r_sun
+        @test ephem.R_body_to_inertial === nothing
         @test length(ephem) == n
 
         # DimensionMismatch
-        @test_throws DimensionMismatch SingleAsteroidEphemerides(times[1:end-1], r_sun)
+        @test_throws DimensionMismatch SingleAsteroidEphemerides{Nothing}(times[1:end-1], r_sun, nothing)
     end
 
-    @testset "SingleAsteroidEphemeridesWithDynamics" begin
-        ephem = SingleAsteroidEphemeridesWithDynamics(times, r_sun, R_body_to_inertial)
+    @testset "SingleAsteroidEphemerides{Vector{SMatrix}}" begin
+        ephem = SingleAsteroidEphemerides(times, r_sun, R_body_to_inertial)
 
         @test ephem.times              === times
         @test ephem.r_sun              === r_sun
         @test ephem.R_body_to_inertial === R_body_to_inertial
         @test length(ephem) == n
 
-        @test_throws DimensionMismatch SingleAsteroidEphemeridesWithDynamics(times, r_sun[1:end-1], R_body_to_inertial)
-        @test_throws DimensionMismatch SingleAsteroidEphemeridesWithDynamics(times, r_sun, R_body_to_inertial[1:end-1])
-
-        # Upgrade constructor
-        ephem_base = SingleAsteroidEphemerides(times, r_sun)
-        ephem_up   = SingleAsteroidEphemeridesWithDynamics(ephem_base, R_body_to_inertial)
-
-        @test ephem_up isa SingleAsteroidEphemeridesWithDynamics
-        @test ephem_up.times === ephem_base.times
-        @test ephem_up.r_sun === ephem_base.r_sun
-        @test ephem_up.R_body_to_inertial === R_body_to_inertial
+        # DimensionMismatch
+        @test_throws DimensionMismatch SingleAsteroidEphemerides(times, r_sun[1:end-1], R_body_to_inertial)
+        @test_throws DimensionMismatch SingleAsteroidEphemerides(times, r_sun, R_body_to_inertial[1:end-1])
     end
 
-    @testset "BinaryAsteroidEphemerides" begin
+    @testset "BinaryAsteroidEphemerides{Nothing}" begin
         ephem = BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary)
 
         @test ephem.times                  === times
         @test ephem.r_sun                  === r_sun
         @test ephem.r_secondary            === r_secondary
         @test ephem.R_primary_to_secondary === R_primary_to_secondary
+        @test ephem.R_primary_to_inertial  === nothing
         @test length(ephem) == n
 
+        # DimensionMismatch
+        @test_throws DimensionMismatch BinaryAsteroidEphemerides{Nothing}(times[1:end-1], r_sun, r_secondary, R_primary_to_secondary, nothing)
         @test_throws DimensionMismatch BinaryAsteroidEphemerides(times, r_sun[1:end-1], r_secondary, R_primary_to_secondary)
         @test_throws DimensionMismatch BinaryAsteroidEphemerides(times, r_sun, r_secondary[1:end-1], R_primary_to_secondary)
         @test_throws DimensionMismatch BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary[1:end-1])
     end
 
-    @testset "BinaryAsteroidEphemeridesWithDynamics" begin
-        ephem = BinaryAsteroidEphemeridesWithDynamics(times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial)
+    @testset "BinaryAsteroidEphemerides{Vector{SMatrix}}" begin
+        ephem = BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial)
 
         @test ephem.times                  === times
         @test ephem.r_sun                  === r_sun
@@ -100,20 +103,10 @@ Unit tests for *Ephemerides types introduced in v0.2.0:
         @test ephem.R_primary_to_inertial  === R_primary_to_inertial
         @test length(ephem) == n
 
-        @test_throws DimensionMismatch BinaryAsteroidEphemeridesWithDynamics(times, r_sun[1:end-1], r_secondary, R_primary_to_secondary, R_primary_to_inertial)
-        @test_throws DimensionMismatch BinaryAsteroidEphemeridesWithDynamics(times, r_sun, r_secondary[1:end-1], R_primary_to_secondary, R_primary_to_inertial)
-        @test_throws DimensionMismatch BinaryAsteroidEphemeridesWithDynamics(times, r_sun, r_secondary, R_primary_to_secondary[1:end-1], R_primary_to_inertial)
-        @test_throws DimensionMismatch BinaryAsteroidEphemeridesWithDynamics(times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial[1:end-1])
-
-        # Upgrade constructor
-        ephem_base = BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary)
-        ephem_up   = BinaryAsteroidEphemeridesWithDynamics(ephem_base, R_primary_to_inertial)
-
-        @test ephem_up isa BinaryAsteroidEphemeridesWithDynamics
-        @test ephem_up.times                  === ephem_base.times
-        @test ephem_up.r_sun                  === ephem_base.r_sun
-        @test ephem_up.r_secondary            === ephem_base.r_secondary
-        @test ephem_up.R_primary_to_secondary === ephem_base.R_primary_to_secondary
-        @test ephem_up.R_primary_to_inertial  === R_primary_to_inertial
+        # DimensionMismatch
+        @test_throws DimensionMismatch BinaryAsteroidEphemerides(times, r_sun[1:end-1], r_secondary, R_primary_to_secondary, R_primary_to_inertial)
+        @test_throws DimensionMismatch BinaryAsteroidEphemerides(times, r_sun, r_secondary[1:end-1], R_primary_to_secondary, R_primary_to_inertial)
+        @test_throws DimensionMismatch BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary[1:end-1], R_primary_to_inertial)
+        @test_throws DimensionMismatch BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial[1:end-1])
     end
 end

--- a/test/test_tpm_with_force.jl
+++ b/test/test_tpm_with_force.jl
@@ -1,0 +1,129 @@
+#=
+test_tpm_with_force.jl
+
+Tests for the force/torque-enabled simulation paths via parametric types:
+    SingleAsteroidEphemerides{<:AbstractVector}  →  SingleAsteroidThermoPhysicalSolution{Vector{SVector{3,Float64}}}
+    BinaryAsteroidEphemerides{<:AbstractVector}  →  BinaryAsteroidThermoPhysicalSolution{Vector{SVector{3,Float64}}}
+
+Covers: _alloc_solution_with_force, record_timestep! {<:AbstractVector},
+        export_solution {<:AbstractVector}, _solve {<:AbstractVector} (single + binary).
+=#
+
+@testset "TPM with force/torque" begin
+    msg = """
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    |             Test: TPM with force/torque                |
+    ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+    """
+    println(msg)
+
+    au2m = AsteroidThermoPhysicalModels.au2m
+
+    # Small orbit: 2 rotations, 36 steps/cycle
+    P            = SPICE.convrt(8, "hours", "seconds")
+    n_cycle      = 2
+    n_step_cycle = 36
+    et_range     = range(0.0, P * n_cycle; length=n_step_cycle * n_cycle + 1)
+    times        = collect(et_range)
+
+    # Rotation matrices: body-fixed rotates with period P around z-axis
+    R_b2i = [SMatrix{3,3,Float64,9}(RotZ(2π * et / P)) for et in et_range]
+
+    # Sun position in body-fixed frame (inverse rotation of inertial position)
+    r_sun = [SVector{3,Float64}(inv(RotZ(2π * et / P)) * SVector(au2m, 0.0, 0.0)) for et in et_range]
+
+    path_obj      = joinpath("shape", "icosahedron.obj")
+    thermo_params = ThermoParams(0.1, 1000.0, 600.0, 0.1, 0.0, 0.9, 0.1, 0.01, 5)
+    times_to_save = times[end-n_step_cycle:end]
+    face_ID       = [1]
+
+    @testset "Single asteroid — {<:AbstractVector}" begin
+        DIR_OUTPUT = mktempdir()
+
+        ephem = SingleAsteroidEphemerides(times, r_sun, R_b2i)
+        @test ephem isa SingleAsteroidEphemerides{Vector{SMatrix{3,3,Float64,9}}}
+
+        shape   = load_shape_obj(path_obj; scale=1000, with_face_visibility=false, with_bvh=false)
+        problem = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
+            with_self_shadowing = false,
+            with_self_heating   = false,
+        )
+
+        solution = solve(problem, CrankNicolson();
+            ephem         = ephem,
+            times_to_save = times_to_save,
+            face_ID       = face_ID,
+            T₀            = 200.0,
+            show_progress = false,
+        )
+
+        # Solution type
+        @test solution isa SingleAsteroidThermoPhysicalSolution{Vector{SVector{3,Float64}}}
+
+        # forces/torques are populated
+        @test solution.forces  isa Vector{SVector{3,Float64}}
+        @test solution.torques isa Vector{SVector{3,Float64}}
+        @test length(solution.forces)  == length(times)
+        @test length(solution.torques) == length(times)
+
+        # export: physical_quantities.csv must contain force/torque columns
+        AsteroidThermoPhysicalModels.export_solution(DIR_OUTPUT, solution)
+        @test isfile(joinpath(DIR_OUTPUT, "physical_quantities.csv"))
+        df = CSV.read(joinpath(DIR_OUTPUT, "physical_quantities.csv"), DataFrame)
+        @test "force_x"  in names(df)
+        @test "force_y"  in names(df)
+        @test "force_z"  in names(df)
+        @test "torque_x" in names(df)
+        @test "torque_y" in names(df)
+        @test "torque_z" in names(df)
+    end
+
+    @testset "Binary asteroid — {<:AbstractVector}" begin
+        DIR_OUTPUT = mktempdir()
+
+        r_secondary            = [SVector{3,Float64}(1e4, 0, 0) for _ in et_range]
+        R_primary_to_secondary = [SMatrix{3,3,Float64,9}(I)     for _ in et_range]
+        R_primary_to_inertial  = R_b2i
+
+        ephem = BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial)
+        @test ephem isa BinaryAsteroidEphemerides{Vector{SMatrix{3,3,Float64,9}}}
+
+        shape1  = load_shape_obj(path_obj; scale=1000, with_face_visibility=false, with_bvh=false)
+        shape2  = load_shape_obj(path_obj; scale=500,  with_face_visibility=false, with_bvh=false)
+        problem = BinaryAsteroidThermoPhysicalProblem(
+            (shape1, shape2),
+            (thermo_params, thermo_params);
+            with_self_shadowing   = false,
+            with_self_heating     = false,
+            with_mutual_shadowing = false,
+            with_mutual_heating   = false,
+        )
+
+        solution = solve(problem, CrankNicolson();
+            ephem         = ephem,
+            times_to_save = times_to_save,
+            face_ID_pri   = face_ID,
+            face_ID_sec   = face_ID,
+            T₀_primary    = 200.0,
+            T₀_secondary  = 200.0,
+            show_progress = false,
+        )
+
+        # Solution type
+        @test solution isa BinaryAsteroidThermoPhysicalSolution{Vector{SVector{3,Float64}}}
+        @test solution.primary   isa SingleAsteroidThermoPhysicalSolution{Vector{SVector{3,Float64}}}
+        @test solution.secondary isa SingleAsteroidThermoPhysicalSolution{Vector{SVector{3,Float64}}}
+
+        # forces/torques are populated for both bodies
+        @test length(solution.primary.forces)    == length(times)
+        @test length(solution.secondary.torques) == length(times)
+
+        # export: both bodies should have force/torque columns
+        AsteroidThermoPhysicalModels.export_solution(DIR_OUTPUT, solution)
+        for body in ("primary", "secondary")
+            df = CSV.read(joinpath(DIR_OUTPUT, body, "physical_quantities.csv"), DataFrame)
+            @test "force_x"  in names(df)
+            @test "torque_x" in names(df)
+        end
+    end
+end

--- a/test/test_tpm_with_force.jl
+++ b/test/test_tpm_with_force.jl
@@ -54,7 +54,7 @@ Covers: _alloc_solution_with_force, record_timestep! {<:AbstractVector},
             times_to_save = times_to_save,
             face_ID       = face_ID,
             T₀            = 200.0,
-            show_progress = false,
+            show_progress = true,
         )
 
         # Solution type
@@ -106,7 +106,7 @@ Covers: _alloc_solution_with_force, record_timestep! {<:AbstractVector},
             face_ID_sec   = face_ID,
             T₀_primary    = 200.0,
             T₀_secondary  = 200.0,
-            show_progress = false,
+            show_progress = true,
         )
 
         # Solution type


### PR DESCRIPTION
## Summary

Implements the parametric type redesign for v0.2.0 I/O overhaul.

Replaces the `*WithDynamics` named-type split with parametric types, solving the 2^N type proliferation problem.

### Key changes

- **`src/ephem_types.jl`**: Rewrite `SingleAsteroidEphemerides` and `BinaryAsteroidEphemerides` as parametric types `{R <: Union{Nothing, AbstractVector}}`, remove `*WithDynamics` variants and exports.
  - `R = Nothing` — temperature only; `R_body_to_inertial = nothing` (zero allocation)
  - `R = Vector{SMatrix{3,3,Float64,9}}` — force/torque in the inertial frame

- **`src/tpm_solution.jl`**: Rewrite `*ThermoPhysicalSolution` as parametric `{F <: Union{Nothing, AbstractVector}}`.
  - Rename `force`/`torque` to `forces`/`torques` (plural, to distinguish from `*State.force`/`torque` which are single `MVector{3}`)
  - `record_timestep!` dispatches on `{Nothing}` (no rotation needed) vs `{<:AbstractVector}` (takes `R` to rotate force/torque to inertial frame)
  - `export_solution` dispatches on solution type: `{Nothing}` omits force/torque columns from `physical_quantities.csv`

- **`src/tpm_solve.jl`**: Update `_solve` dispatch signatures from `*WithDynamics` types to `{Nothing}` / `{<:AbstractVector}`; replace stub `error(...)` methods with real implementations for the force/torque variants.

- **`test/test_ephem_types.jl`**: Update tests for the new parametric types.
- **`test/test_tpm_with_force.jl`**: Add tests for the `{<:AbstractVector}` code paths (single + binary asteroid with force/torque).

### Design rationale

Three approaches were considered:

| Aspect | `*WithDynamics` split | Flag (`compute_force::Bool`) | Parametric `{R}` (adopted) |
|---|---|---|---|
| Type names | 2^N named types | 2 names | 2 names |
| Memory (no force) | efficient (no R field in base type) | always allocates R vectors | `nothing` = zero allocation |
| Type stability | ✓ | ✓ | ✓ |
| Future extensibility | type names grow exponentially | add a flag | add a type parameter |
| Julia idiom | ✓ | △ | ✓ (same approach as SciML) |

The `*WithDynamics` split is memory-efficient but causes 2^N type name explosion as features are added (e.g. adding `HierarchicalShapeModel` in v0.3.0 would yield 8 named types). The flag approach avoids this but always allocates identity-matrix vectors for the R field even when unused. Parametric types solve both problems.

### Out of scope (future PRs)

- `OutputSpec` type introduction
- `subsolar_temperature(r☉, params)` removal
- `subsurface_temperature.csv` column sort bug fix
- `times_to_save` validation

## Test plan

- [x] All existing tests pass (`Pkg.test()`)
- [x] Aqua.jl checks pass (no unbound type parameters, no undefined exports, etc.)
- [x] TPM_Ryugu, TPM_Didymos, TPM_non-uniform_thermoparams, TPM_zero-conductivity end-to-end tests pass
- [x] `test_ephem_types.jl` unit tests for parametric type construction, field access, and `DimensionMismatch` validation
- [x] `test_tpm_with_force.jl` unit tests for `{<:AbstractVector}` solve, record, and export paths (single + binary)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)