### PR TITLE
refactor: remove subsolar_temperature(r☉, params) overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,6 @@ solution = solve(problem, CrankNicolson();
 
 - `export_solution(dirpath, solution)`: export simulation results to CSV files; replaces `export_TPM_results`
   - `physical_quantities.csv` includes `force_x/y/z` and `torque_x/y/z` columns when `F <: AbstractVector`
-- `subsolar_temperature(r☉, params)` is now publicly exported
 - `ThermoParams` is now publicly exported (previously required `AsteroidThermoPhysicalModels.ThermoParams`)
 
 ### Changed
@@ -70,6 +69,7 @@ solution = solve(problem, CrankNicolson();
 
 - `run_TPM!`: replaced by `solve(problem, algorithm; kwargs...)`
 - `export_TPM_results`: replaced by `export_solution`
+- `subsolar_temperature(r☉, params::AbstractThermoParams)` overload: used `params.reflectance_vis[begin]` and `params.emissivity[begin]` silently, which is semantically inconsistent for non-uniform `ThermoParams`; use `subsolar_temperature(r☉, R_vis, ε)` directly instead
 
 ### Internal
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,7 +80,7 @@ Redesign the API around a Problem-Solver pattern inspired by `DifferentialEquati
   - [ ] `OutputSpec` type to encapsulate output settings (`times_to_save`, `face_ID`); replaces individual keyword arguments in `solve`
 
 - [ ] **API Cleanup**
-  - [ ] Remove `subsolar_temperature(r☉, params)` overload; use the explicit scalar form `subsolar_temperature(r☉, R_vis, ε)` instead
+  - [x] Remove `subsolar_temperature(r☉, params)` overload; use the explicit scalar form `subsolar_temperature(r☉, R_vis, ε)` instead
 
 ## v0.2.1 - Configuration File Support (Target: 2026)
 

--- a/src/thermo_params.jl
+++ b/src/thermo_params.jl
@@ -186,7 +186,6 @@ end
 
 """
     subsolar_temperature(r☉, R_vis, ε) -> Tₛₛ
-    subsolar_temperature(r☉, params::AbstractThermoParams) -> Tₛₛ
 
 Calculate the subsolar equilibrium temperature at a given heliocentric distance.
 
@@ -202,19 +201,12 @@ Calculate the subsolar equilibrium temperature at a given heliocentric distance.
 Assumes instantaneous radiative equilibrium (zero thermal inertia). Useful as an
 upper bound for surface temperatures and as an initial guess for `T₀`.
 
-!!! warning "TODO"
-    The `params` overload silently uses `params.reflectance_vis[begin]` and
-    `params.emissivity[begin]`, which is inconsistent for non-uniform `ThermoParams`.
-    This overload will be removed in a future release; use `subsolar_temperature(r☉, R_vis, ε)` directly.
-
 # Mathematical Formula
 ```math
 T_{ss} = \\left[\\frac{(1 - A) \\Phi_\\odot}{\\varepsilon \\sigma}\\right]^{1/4}
 ```
 where ``\\Phi_\\odot = \\Phi_0 / r^2`` is the solar flux at heliocentric distance ``r``.
 """
-subsolar_temperature(r☉, params::AbstractThermoParams) = subsolar_temperature(r☉, params.reflectance_vis[begin], params.emissivity[begin])
-
 function subsolar_temperature(r☉, R_vis, ε)
     Φ = SOLAR_CONST / (norm(r☉) * m2au)^2
     return ((1 - R_vis) * Φ / (ε * σ_SB))^(1/4)

--- a/src/tpm_solve.jl
+++ b/src/tpm_solve.jl
@@ -127,8 +127,8 @@ Run a thermophysical simulation for a binary asteroid system.
 
 # Example
 ```julia
-T₀_primary   = subsolar_temperature(ephem.r_sun[begin], params1)
-T₀_secondary = subsolar_temperature(ephem.r_sun[begin], params2)
+T₀_primary   = subsolar_temperature(ephem.r_sun[begin], R_vis, ε)
+T₀_secondary = subsolar_temperature(ephem.r_sun[begin], R_vis, ε)
 solution = solve(problem, CrankNicolson();
     ephem         = ephem,
     times_to_save = times_to_save,

--- a/test/test_problem_api.jl
+++ b/test/test_problem_api.jl
@@ -26,13 +26,12 @@ Unit tests for the Problem-Solver API introduced in v0.2.0:
         r☉_1au  = SVector{3, Float64}(1 * au2m, 0, 0)
         r☉_2au  = SVector{3, Float64}(2 * au2m, 0, 0)
 
-        Tss_1au = subsolar_temperature(r☉_1au, thermo_params1)
-        Tss_2au = subsolar_temperature(r☉_2au, thermo_params1)
+        Tss_1au = subsolar_temperature(r☉_1au, 0.1, 0.9)
+        Tss_2au = subsolar_temperature(r☉_2au, 0.1, 0.9)
 
         @test Tss_1au > 0
         @test Tss_1au isa Float64
-        @test subsolar_temperature(r☉_1au, 0.1, 0.9) ≈ Tss_1au  # two-argument form
-        @test Tss_2au < Tss_1au                                 # farther from Sun → cooler
+        @test Tss_2au < Tss_1au  # farther from Sun → cooler
     end
 
     @testset "BinaryAsteroidThermoPhysicalProblem convenience constructor" begin


### PR DESCRIPTION
## Summary

- Remove `subsolar_temperature(r☉, params::AbstractThermoParams)` overload, which silently used `params.reflectance_vis[begin]` and `params.emissivity[begin]` — semantically inconsistent for non-uniform `ThermoParams`
- Update docstring, docstring example in `tpm_solve.jl`, and tests to use the explicit scalar form `subsolar_temperature(r☉, R_vis, ε)` directly
- Update CHANGELOG and ROADMAP accordingly

Note: `subsurface_temperature.csv` column sort was also listed as a planned fix, but the current implementation already uses integer-based sorting (`by=x->parse(Int, ...)`), so no change was needed.

## Test plan

- [x] All existing tests pass (`julia --project=. -e "using Pkg; Pkg.test()"`)
- [x] No remaining uses of the removed overload in source, tests, or docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)