### PR TITLE
ci: update GitHub Actions versions and fix macOS arm64 arch mismatch

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -19,15 +19,12 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        arch:
-          - x64
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1


### PR DESCRIPTION
## Summary

- `actions/checkout`: v6 → v7
- `julia-actions/setup-julia`: v2 → v3
- `julia-actions/cache`: v2 → v3
- Remove `arch: x64` from the test matrix

## Background

`macOS-latest` runners are now Apple Silicon (arm64). `julia-actions/setup-julia` v3 correctly rejects the mismatch between the requested `x64` arch and the runner's arm64 architecture (v2 was silently ignoring it). Removing `arch` from the matrix lets each OS use its native architecture:

- ubuntu-latest → x64
- macOS-latest → aarch64
- windows-latest → x64

Supersedes Dependabot PRs #198, #199, #207.

## Test plan

- [x] CI passes on ubuntu, macOS (aarch64), and windows across Julia 1.10, 1, and nightly

🤖 Generated with [Claude Code](https://claude.com/claude-code)