### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - TBD
+## [0.2.0] - 2026-06-24
 
 This release introduces a Problem-Solver API redesign inspired by `DifferentialEquations.jl`.
 The old `run_TPM!` function is replaced by `solve(problem, algorithm; kwargs...)`.
@@ -16,12 +16,16 @@ The old `run_TPM!` function is replaced by `solve(problem, algorithm; kwargs...)
 
 ```julia
 # v0.1.x
-stpm = SingleAsteroidThermoPhysicalModel(shape, thermo_params; ...)
+ephem = (time = times, sun = r_sun)   # NamedTuple with `time` and `sun` fields
+stpm  = SingleAsteroidThermoPhysicalModel(shape, thermo_params; ...)
 result = run_TPM!(stpm, ephem, times_to_save, face_ID)
 
 # v0.2.0
-problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params; ...)
-output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids;
+ephem   = SingleAsteroidEphemerides(times, r_sun)
+# ephem = SingleAsteroidEphemerides(times, r_sun, R_body_to_inertial)  # for force/torque output
+
+problem  = SingleAsteroidThermoPhysicalProblem(shape, thermo_params; ...)
+output   = SingleAsteroidOutputSpec(output_times, subsurface_face_ids;
     save_surface_temperature    = true,
     save_subsurface_temperature = true,
     save_face_forces            = false,

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AsteroidThermoPhysicalModels"
 uuid = "ab46f4a3-3c83-4d86-98d6-41a8b1a2e76e"
 authors = ["Masanori Kanamaru"]
-version = "0.2.0-DEV"
+version = "0.2.0"
 
 [deps]
 AsteroidShapeModels = "a7943d8e-5d65-4248-ae23-0082f5115a05"

--- a/README.md
+++ b/README.md
@@ -46,13 +46,40 @@ pkg> add AsteroidThermoPhysicalModels
 - **Yarkovsky Effect**: Orbital perturbation due to asymmetric thermal emission
 - **YORP Effect**: Rotational perturbation due to asymmetric thermal emission
 
-### Coming in v0.2.0
-- Surface roughness modeling using `HierarchicalShapeModel` from `AsteroidShapeModels.jl`
-- Enhanced heat conduction solver validation and benchmarks
+## 🆕 What's New in v0.2.0
 
-## 🆕 What's New in v0.1.x
+This release introduces a **Problem-Solver API** inspired by `DifferentialEquations.jl`, replacing the old `run_TPM!` function.
 
-### v0.1.1
+### API Redesign (Breaking)
+
+```julia
+# v0.1.x
+ephem  = (time = times, sun = r_sun)   # NamedTuple
+stpm   = SingleAsteroidThermoPhysicalModel(shape, thermo_params; ...)
+result = run_TPM!(stpm, ephem, times_to_save, face_ID)
+
+# v0.2.0
+ephem   = SingleAsteroidEphemerides(times, r_sun)
+problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params; ...)
+output  = SingleAsteroidOutputSpec(output_times, subsurface_face_ids;
+    save_surface_temperature    = true,
+    save_subsurface_temperature = true,
+    save_face_forces            = false,
+    save_forces                 = false,  # true requires R_body_to_inertial in ephem
+    save_torques                = false,
+)
+solution = solve(problem, CrankNicolson();
+    ephem               = ephem,
+    output              = output,
+    initial_temperature = 200.0,
+)
+```
+
+See the [Migration Guide](CHANGELOG.md#migration-guide) and [CHANGELOG](CHANGELOG.md) for details.
+
+### What's New in v0.1.x
+
+#### v0.1.1
 - **Performance**: Shadow calculations are ~2.7x faster via `AsteroidShapeModels.jl` v0.4.2
 - **Compatibility**: Now supports `AsteroidShapeModels.jl` v0.5.x, which introduces `HierarchicalShapeModel` for future surface roughness support
 - **Bug fix**: Updated HERA SPICE kernel download URLs (ESA BitBucket now requires authentication)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,11 +60,7 @@ The v0.1.0 release marks a significant milestone with stabilized core APIs, crit
   - [x] Split `src/TPM.jl` into focused files: `solver_types.jl`, `tpm_types.jl`, `tpm_result.jl`, `tpm_run.jl`
   - [x] Remove geometric operation tests that duplicate `AsteroidShapeModels.jl` tests
 
----
-**↓ Planned Releases ↓**
----
-
-## v0.2.0 - API Redesign (Target: 2026)
+## v0.2.0 - API Redesign (Released: 2026-06-24)
 
 Redesign the API around a Problem-Solver pattern inspired by `DifferentialEquations.jl`. Separating problem definition from simulation state provides the clean internal architecture needed to implement surface roughness support in v0.3.0.
 
@@ -81,6 +77,10 @@ Redesign the API around a Problem-Solver pattern inspired by `DifferentialEquati
 
 - [x] **API Cleanup**
   - [x] Remove `subsolar_temperature(r☉, params)` overload; use the explicit scalar form `subsolar_temperature(r☉, R_vis, ε)` instead
+
+---
+**↓ Planned Releases ↓**
+---
 
 ## v0.2.1 - Configuration File Support (Target: 2026)
 


### PR DESCRIPTION
## Summary

- Bump `Project.toml` version: `0.2.0-DEV` → `0.2.0`
- Update `CHANGELOG.md`: set release date to 2026-06-24; expand migration guide with before/after `ephem` construction and full `solve()` call
- Update `ROADMAP.md`: mark v0.2.0 as released (`Released: 2026-06-24`), move planned-releases separator to v0.2.1
- Update `README.md`: replace "Coming in v0.2.0" placeholder with a "What's New in v0.2.0" section including a before/after migration guide

## Checklist

- [x] `Project.toml` version updated
- [x] `CHANGELOG.md` release date set
- [x] `ROADMAP.md` updated
- [x] `README.md` What's New section added

## Next steps after merge

Post `@JuliaRegistrator register` comment on this PR to trigger General Registry registration. TagBot will auto-create the tag and GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)