### PR TITLE
refactor: remove `AsteroidThermoPhysicalModels.` prefix from exported symbols in tests

### DIFF
--- a/test/TPM_Didymos/TPM_Didymos.jl
+++ b/test/TPM_Didymos/TPM_Didymos.jl
@@ -106,21 +106,21 @@ See https://github.com/Astroshaper/Astroshaper-examples/tree/main/TPM_Didymos fo
     thermo_params2 = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
 
     ## --- Setting of TPM ---
-    prob1 = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalProblem(shape1, thermo_params1;
+    prob1 = SingleAsteroidThermoPhysicalProblem(shape1, thermo_params1;
         with_self_shadowing      = true,
         with_self_heating        = true,
-        upper_boundary_condition = AsteroidThermoPhysicalModels.RadiationBoundaryCondition(),
-        lower_boundary_condition = AsteroidThermoPhysicalModels.InsulationBoundaryCondition(),
+        upper_boundary_condition = RadiationBoundaryCondition(),
+        lower_boundary_condition = InsulationBoundaryCondition(),
     )
 
-    prob2 = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalProblem(shape2, thermo_params2;
+    prob2 = SingleAsteroidThermoPhysicalProblem(shape2, thermo_params2;
         with_self_shadowing      = true,
         with_self_heating        = true,
-        upper_boundary_condition = AsteroidThermoPhysicalModels.RadiationBoundaryCondition(),
-        lower_boundary_condition = AsteroidThermoPhysicalModels.InsulationBoundaryCondition(),
+        upper_boundary_condition = RadiationBoundaryCondition(),
+        lower_boundary_condition = InsulationBoundaryCondition(),
     )
 
-    problem = AsteroidThermoPhysicalModels.BinaryAsteroidThermoPhysicalProblem(prob1, prob2;
+    problem = BinaryAsteroidThermoPhysicalProblem(prob1, prob2;
         with_mutual_shadowing = true,
         with_mutual_heating   = true,
     )
@@ -143,7 +143,7 @@ See https://github.com/Astroshaper/Astroshaper-examples/tree/main/TPM_Didymos fo
 
     ## --- Save TPM result ---
     @testset "Save TPM result" begin
-        AsteroidThermoPhysicalModels.export_solution(DIR_OUTPUT, solution)
+        export_solution(DIR_OUTPUT, solution)
 
         @test isfile(joinpath(DIR_OUTPUT, "primary", "diagnostics.csv"))
         @test isfile(joinpath(DIR_OUTPUT, "primary", "surface_temperature.csv"))

--- a/test/TPM_Ryugu/TPM_Ryugu.jl
+++ b/test/TPM_Ryugu/TPM_Ryugu.jl
@@ -81,8 +81,8 @@ See https://github.com/Astroshaper/Astroshaper-examples/tree/main/TPM_Ryugu for 
     ρ  = 1270.0  # Density [kg/m³]
     Cₚ = 600.0   # Heat capacity [J/kg/K]
 
-    l = AsteroidThermoPhysicalModels.thermal_skin_depth(P, k, ρ, Cₚ)  # Thermal skin depth [m]
-    Γ = AsteroidThermoPhysicalModels.thermal_inertia(k, ρ, Cₚ)        # Thermal inertia [tiu]
+    l = thermal_skin_depth(P, k, ρ, Cₚ)  # Thermal skin depth [m]
+    Γ = thermal_inertia(k, ρ, Cₚ)        # Thermal inertia [tiu]
 
     R_vis = 0.04  # Reflectance in visible light [-]
     R_ir  = 0.0   # Reflectance in thermal infrared [-]
@@ -95,11 +95,11 @@ See https://github.com/Astroshaper/Astroshaper-examples/tree/main/TPM_Ryugu for 
     thermo_params = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
 
     ## --- Setting of TPM ---
-    problem = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
+    problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
         with_self_shadowing      = true,
         with_self_heating        = true,
-        upper_boundary_condition = AsteroidThermoPhysicalModels.RadiationBoundaryCondition(),
-        lower_boundary_condition = AsteroidThermoPhysicalModels.InsulationBoundaryCondition(),
+        upper_boundary_condition = RadiationBoundaryCondition(),
+        lower_boundary_condition = InsulationBoundaryCondition(),
     )
 
     ## --- Run TPM ---
@@ -115,7 +115,7 @@ See https://github.com/Astroshaper/Astroshaper-examples/tree/main/TPM_Ryugu for 
 
     ## --- Save TPM result ---
     @testset "Save TPM result" begin
-        AsteroidThermoPhysicalModels.export_solution(DIR_OUTPUT, solution)
+        export_solution(DIR_OUTPUT, solution)
 
         @test isfile(joinpath(DIR_OUTPUT, "diagnostics.csv"))
         @test isfile(joinpath(DIR_OUTPUT, "surface_temperature.csv"))

--- a/test/TPM_non-uniform_thermoparams/TPM_non-uniform_thermoparams.jl
+++ b/test/TPM_non-uniform_thermoparams/TPM_non-uniform_thermoparams.jl
@@ -105,11 +105,11 @@ Based on TPM_Ryugu test but with varying thermophysical properties.
     thermo_params = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
 
     ## --- Setting of TPM ---
-    problem = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
+    problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
         with_self_shadowing      = true,
         with_self_heating        = true,
-        upper_boundary_condition = AsteroidThermoPhysicalModels.RadiationBoundaryCondition(),
-        lower_boundary_condition = AsteroidThermoPhysicalModels.InsulationBoundaryCondition(),
+        upper_boundary_condition = RadiationBoundaryCondition(),
+        lower_boundary_condition = InsulationBoundaryCondition(),
     )
 
     ## --- Run TPM ---
@@ -125,7 +125,7 @@ Based on TPM_Ryugu test but with varying thermophysical properties.
 
     ## --- Save TPM result ---
     @testset "Save TPM result" begin
-        AsteroidThermoPhysicalModels.export_solution(DIR_OUTPUT, solution)
+        export_solution(DIR_OUTPUT, solution)
     
         @test isfile(joinpath(DIR_OUTPUT, "diagnostics.csv"))
         @test isfile(joinpath(DIR_OUTPUT, "surface_temperature.csv"))

--- a/test/TPM_zero-conductivity/TPM_zero-conductivity.jl
+++ b/test/TPM_zero-conductivity/TPM_zero-conductivity.jl
@@ -55,11 +55,11 @@ This test validates:
     thermo_params = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
 
     ## --- Setting of TPM ---
-    problem = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
+    problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
         with_self_shadowing      = true,
         with_self_heating        = false,
-        upper_boundary_condition = AsteroidThermoPhysicalModels.RadiationBoundaryCondition(),
-        lower_boundary_condition = AsteroidThermoPhysicalModels.InsulationBoundaryCondition(),
+        upper_boundary_condition = RadiationBoundaryCondition(),
+        lower_boundary_condition = InsulationBoundaryCondition(),
     )
 
     ## --- Run TPM ---
@@ -75,7 +75,7 @@ This test validates:
 
     ## --- Save TPM result ---
     @testset "Save TPM result" begin
-        AsteroidThermoPhysicalModels.export_solution(DIR_OUTPUT, solution)
+        export_solution(DIR_OUTPUT, solution)
 
         @test isfile(joinpath(DIR_OUTPUT, "diagnostics.csv"))
         @test isfile(joinpath(DIR_OUTPUT, "surface_temperature.csv"))

--- a/test/heat_conduction_1D.jl
+++ b/test/heat_conduction_1D.jl
@@ -42,8 +42,8 @@ Tests for 1D heat conduction solvers:
     thermo_params = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
 
     ## --- Build states with different solvers ---
-    BC_UPPER = AsteroidThermoPhysicalModels.IsothermalBoundaryCondition(0)
-    BC_LOWER = AsteroidThermoPhysicalModels.IsothermalBoundaryCondition(0)
+    BC_UPPER = IsothermalBoundaryCondition(0)
+    BC_LOWER = IsothermalBoundaryCondition(0)
 
     problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
         with_self_shadowing      = false,

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -40,8 +40,8 @@ Validates both upper and lower boundary implementations.
 
     @testset "Isothermal BC with non-zero temperatures" begin
         # Test with T_upper = 100, T_lower = 50
-        BC_UPPER = AsteroidThermoPhysicalModels.IsothermalBoundaryCondition(100.0)
-        BC_LOWER = AsteroidThermoPhysicalModels.IsothermalBoundaryCondition(50.0)
+        BC_UPPER = IsothermalBoundaryCondition(100.0)
+        BC_LOWER = IsothermalBoundaryCondition(50.0)
 
         problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
             with_self_shadowing      = false,
@@ -70,8 +70,8 @@ Validates both upper and lower boundary implementations.
     end
 
     @testset "Insulation BC at lower boundary" begin
-        BC_UPPER = AsteroidThermoPhysicalModels.IsothermalBoundaryCondition(100.0)
-        BC_LOWER = AsteroidThermoPhysicalModels.InsulationBoundaryCondition()
+        BC_UPPER = IsothermalBoundaryCondition(100.0)
+        BC_LOWER = InsulationBoundaryCondition()
 
         problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
             with_self_shadowing      = false,

--- a/test/test_tpm_with_force.jl
+++ b/test/test_tpm_with_force.jl
@@ -44,7 +44,7 @@ Covers: _alloc_solution (with forces/torques), record_timestep! (with R),
         @test ephem isa SingleAsteroidEphemerides{Vector{SMatrix{3,3,Float64,9}}}
 
         shape   = load_shape_obj(path_obj; scale=1000, with_face_visibility=false, with_bvh=false)
-        problem = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
+        problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
             with_self_shadowing = false,
             with_self_heating   = false,
         )
@@ -67,7 +67,7 @@ Covers: _alloc_solution (with forces/torques), record_timestep! (with R),
         @test length(solution.torques) == length(output_times)
 
         # export: thermal_net_forces.csv must contain force/torque columns
-        AsteroidThermoPhysicalModels.export_solution(DIR_OUTPUT, solution)
+        export_solution(DIR_OUTPUT, solution)
         @test isfile(joinpath(DIR_OUTPUT, "thermal_net_forces.csv"))
         df = CSV.read(joinpath(DIR_OUTPUT, "thermal_net_forces.csv"), DataFrame)
         @test "force_x"  in names(df)
@@ -85,7 +85,7 @@ Covers: _alloc_solution (with forces/torques), record_timestep! (with R),
         ephem_no_rot = SingleAsteroidEphemerides(times, r_sun)
 
         shape   = load_shape_obj(path_obj; scale=1000, with_face_visibility=false, with_bvh=false)
-        problem = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
+        problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
             with_self_shadowing = false,
             with_self_heating   = false,
         )
@@ -107,7 +107,7 @@ Covers: _alloc_solution (with forces/torques), record_timestep! (with R),
         @test size(solution.face_forces) == (n_face, length(output_times))
 
         # export: thermal_face_forces.csv must be written with correct columns
-        AsteroidThermoPhysicalModels.export_solution(DIR_OUTPUT, solution)
+        export_solution(DIR_OUTPUT, solution)
         @test isfile(joinpath(DIR_OUTPUT, "thermal_face_forces.csv"))
         df = CSV.read(joinpath(DIR_OUTPUT, "thermal_face_forces.csv"), DataFrame)
         @test "force_x" in names(df)
@@ -159,7 +159,7 @@ Covers: _alloc_solution (with forces/torques), record_timestep! (with R),
         @test length(solution.secondary.torques) == length(output_times)
 
         # export: both bodies should have thermal_net_forces.csv with force/torque columns
-        AsteroidThermoPhysicalModels.export_solution(DIR_OUTPUT, solution)
+        export_solution(DIR_OUTPUT, solution)
         for body in ("primary", "secondary")
             filepath = joinpath(DIR_OUTPUT, body, "thermal_net_forces.csv")
             df = CSV.read(filepath, DataFrame)

--- a/test/thermal_radiation.jl
+++ b/test/thermal_radiation.jl
@@ -64,8 +64,8 @@ This test validates:
     ρ  = 1270.0  # Density [kg/m³]
     Cₚ = 600.0   # Heat capacity [J/kg/K]
     
-    l = AsteroidThermoPhysicalModels.thermal_skin_depth(P, k, ρ, Cₚ)
-    Γ = AsteroidThermoPhysicalModels.thermal_inertia(k, ρ, Cₚ)
+    l = thermal_skin_depth(P, k, ρ, Cₚ)
+    Γ = thermal_inertia(k, ρ, Cₚ)
 
     R_vis = 0.04  # Reflectance in visible light [-]
     R_ir  = 0.0   # Reflectance in thermal infrared [-]


### PR DESCRIPTION
## Summary

Remove unnecessary `AsteroidThermoPhysicalModels.` module prefix from exported symbols in test files. Unexported internal symbols (`au2m`, `_build_*`, `init_temperature!`, etc.) retain the prefix as required.

**Removed prefix from:**
- `IsothermalBoundaryCondition`, `RadiationBoundaryCondition`, `InsulationBoundaryCondition`
- `SingleAsteroidThermoPhysicalProblem`, `BinaryAsteroidThermoPhysicalProblem`
- `thermal_skin_depth`, `thermal_inertia`
- `export_solution`

**Retained prefix on (unexported):**
- `au2m`, `_build_single_state`, `_build_binary_state`, `_validate_output_spec`
- `init_temperature!`, `update_temperature!`, `explicit_euler!`, `implicit_euler!`, `crank_nicolson!`
- `blackbody_radiance`, `σ_SB`, `thermal_radiance`, `analytical_solution_isothermal`

All tests pass locally.

## Part of v0.2.1 patch fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)