### PR TITLE
feat: auto-convert plain Arrays to `StaticArrays` in `*Ephemerides` constructors

### DIFF
--- a/src/ephem_types.jl
+++ b/src/ephem_types.jl
@@ -17,6 +17,20 @@ Type parameter R:
 =#
 
 # ╔═══════════════════════════════════════════════════════════════════╗
+# ║                     Conversion helpers                            ║
+# ╚═══════════════════════════════════════════════════════════════════╝
+
+# Two methods per helper: the first is a no-op fast path when the element type
+# already matches (avoids element-wise allocation); the second converts each
+# element so users need not import StaticArrays themselves.
+
+_to_svec3_vec(v::AbstractVector{SVector{3,Float64}}) = convert(Vector{SVector{3,Float64}}, v)
+_to_svec3_vec(v::AbstractVector) = [SVector{3,Float64}(x) for x in v]
+
+_to_smat33_vec(v::AbstractVector{SMatrix{3,3,Float64,9}}) = convert(Vector{SMatrix{3,3,Float64,9}}, v)
+_to_smat33_vec(v::AbstractVector) = [SMatrix{3,3,Float64,9}(x) for x in v]
+
+# ╔═══════════════════════════════════════════════════════════════════╗
 # ║                       Abstract types                              ║
 # ╚═══════════════════════════════════════════════════════════════════╝
 
@@ -70,8 +84,15 @@ The type parameter `R` controls whether force and torque are computed:
 # Constructors
     SingleAsteroidEphemerides(times, r_sun)
         -> SingleAsteroidEphemerides{Nothing}
+    SingleAsteroidEphemerides(times, r_sun, nothing)
+        -> SingleAsteroidEphemerides{Nothing}
     SingleAsteroidEphemerides(times, r_sun, R_body_to_inertial)
-        -> SingleAsteroidEphemerides{typeof(R_body_to_inertial)}
+        -> SingleAsteroidEphemerides{Vector{SMatrix{3,3,Float64,9}}}
+
+Plain `AbstractVector` / `AbstractMatrix` elements in `r_sun` and
+`R_body_to_inertial` are automatically converted to the corresponding
+`SVector{3,Float64}` / `SMatrix{3,3,Float64,9}` types, so importing
+`StaticArrays` in user code is not required.
 """
 struct SingleAsteroidEphemerides{R <: Union{Nothing, AbstractVector}} <: AbstractSingleAsteroidEphemerides
     times              ::Vector{Float64}
@@ -90,17 +111,23 @@ struct SingleAsteroidEphemerides{R <: Union{Nothing, AbstractVector}} <: Abstrac
         R_body_to_inertial === nothing || length(R_body_to_inertial) == n || throw(DimensionMismatch(
             "R_body_to_inertial ($(length(R_body_to_inertial))) and times ($n) must have the same length"
         ))
-        new{R}(times, r_sun, R_body_to_inertial)
+        new{R}(times, _to_svec3_vec(r_sun), R_body_to_inertial)
     end
 end
 
-# Temperature only: R_body_to_inertial = nothing
+# Temperature only (R_body_to_inertial = nothing), implicit or explicit.
 SingleAsteroidEphemerides(times, r_sun) =
     SingleAsteroidEphemerides{Nothing}(times, r_sun, nothing)
+SingleAsteroidEphemerides(times, r_sun, ::Nothing) =
+    SingleAsteroidEphemerides{Nothing}(times, r_sun, nothing)
 
-# With rotation matrices for force/torque computation
-SingleAsteroidEphemerides(times, r_sun, R_body_to_inertial) =
-    SingleAsteroidEphemerides{typeof(R_body_to_inertial)}(times, r_sun, R_body_to_inertial)
+# With rotation matrices for force/torque computation.
+# Converted here (before the inner constructor) so that the type parameter R is
+# correctly inferred as Vector{SMatrix{3,3,Float64,9}}.
+function SingleAsteroidEphemerides(times, r_sun, R_body_to_inertial)
+    R_conv = _to_smat33_vec(R_body_to_inertial)
+    SingleAsteroidEphemerides{typeof(R_conv)}(times, r_sun, R_conv)
+end
 
 
 # ╔═══════════════════════════════════════════════════════════════════╗
@@ -133,8 +160,13 @@ R_{s2i} = R_{p2i} \\cdot R_{p2s}^{\\top}
 # Constructors
     BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary)
         -> BinaryAsteroidEphemerides{Nothing}
+    BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary, nothing)
+        -> BinaryAsteroidEphemerides{Nothing}
     BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial)
-        -> BinaryAsteroidEphemerides{typeof(R_primary_to_inertial)}
+        -> BinaryAsteroidEphemerides{Vector{SMatrix{3,3,Float64,9}}}
+
+Plain `AbstractVector` / `AbstractMatrix` elements are automatically converted
+to `SVector{3,Float64}` / `SMatrix{3,3,Float64,9}` types in all fields.
 """
 struct BinaryAsteroidEphemerides{R <: Union{Nothing, AbstractVector}} <: AbstractBinaryAsteroidEphemerides
     times                  ::Vector{Float64}
@@ -163,16 +195,26 @@ struct BinaryAsteroidEphemerides{R <: Union{Nothing, AbstractVector}} <: Abstrac
         R_primary_to_inertial === nothing || length(R_primary_to_inertial) == n || throw(DimensionMismatch(
             "R_primary_to_inertial ($(length(R_primary_to_inertial))) and times ($n) must have the same length"
         ))
-        new{R}(times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial)
+        new{R}(
+            times,
+            _to_svec3_vec(r_sun),
+            _to_svec3_vec(r_secondary),
+            _to_smat33_vec(R_primary_to_secondary),
+            R_primary_to_inertial,
+        )
     end
 end
 
-# Temperature only: R_primary_to_inertial = nothing
+# Temperature only (R_primary_to_inertial = nothing), implicit or explicit.
 BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary) =
     BinaryAsteroidEphemerides{Nothing}(times, r_sun, r_secondary, R_primary_to_secondary, nothing)
+BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary, ::Nothing) =
+    BinaryAsteroidEphemerides{Nothing}(times, r_sun, r_secondary, R_primary_to_secondary, nothing)
 
-# With rotation matrices for force/torque computation
-BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial) =
-    BinaryAsteroidEphemerides{typeof(R_primary_to_inertial)}(
-        times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial,
-    )
+# With rotation matrices for force/torque computation.
+# Converted here (before the inner constructor) so that the type parameter R is
+# correctly inferred as Vector{SMatrix{3,3,Float64,9}}.
+function BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial)
+    R_conv = _to_smat33_vec(R_primary_to_inertial)
+    BinaryAsteroidEphemerides{typeof(R_conv)}(times, r_sun, r_secondary, R_primary_to_secondary, R_conv)
+end

--- a/test/TPM_Didymos/TPM_Didymos.jl
+++ b/test/TPM_Didymos/TPM_Didymos.jl
@@ -71,9 +71,12 @@ See https://github.com/Astroshaper/Astroshaper-examples/tree/main/TPM_Didymos fo
     et_range = range(et_begin, et_end; length=n_step_in_cycle*n_cycle+1)
 
     times                  = collect(et_range)
-    r_sun                  = [SVector{3}(SPICE.spkpos("SUN"      , et, "DIDYMOS_FIXED", "None", "DIDYMOS")[1]) * 1000 for et in et_range]  # Sun's position in DIDYMOS_FIXED [m]
-    r_secondary            = [SVector{3}(SPICE.spkpos("DIMORPHOS", et, "DIDYMOS_FIXED", "None", "DIDYMOS")[1]) * 1000 for et in et_range]  # Dimorphos position in DIDYMOS_FIXED [m]
-    R_primary_to_secondary = [RotMatrix{3}(SPICE.pxform("DIDYMOS_FIXED", "DIMORPHOS_FIXED", et)) for et in et_range]
+    r_sun                  = [SPICE.spkpos("SUN"      , et, "DIDYMOS_FIXED", "None", "DIDYMOS")[1] for et in et_range]  # Sun's position in DIDYMOS_FIXED [km]
+    r_secondary            = [SPICE.spkpos("DIMORPHOS", et, "DIDYMOS_FIXED", "None", "DIDYMOS")[1] for et in et_range]  # Dimorphos position in DIDYMOS_FIXED [km]
+    R_primary_to_secondary = [SPICE.pxform("DIDYMOS_FIXED", "DIMORPHOS_FIXED", et) for et in et_range]
+
+    r_sun       .*= 1000  # Convert [km] to [m]
+    r_secondary .*= 1000  # Convert [km] to [m]
 
     ephem = BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary)
 

--- a/test/TPM_Ryugu/TPM_Ryugu.jl
+++ b/test/TPM_Ryugu/TPM_Ryugu.jl
@@ -63,7 +63,9 @@ See https://github.com/Astroshaper/Astroshaper-examples/tree/main/TPM_Ryugu for 
     et_range = range(et_begin, et_end; length=n_step_in_cycle*n_cycle+1)
 
     times = collect(et_range)
-    r_sun = [SVector{3}(SPICE.spkpos("SUN", et, "RYUGU_FIXED", "None", "RYUGU")[1]) * 1000 for et in et_range]  # Sun's position in RYUGU_FIXED [m]
+    r_sun = [SPICE.spkpos("SUN", et, "RYUGU_FIXED", "None", "RYUGU")[1] for et in et_range]  # Sun's position in RYUGU_FIXED [km]
+    r_sun .*= 1000  # Convert [km] to [m]
+
 
     ephem = SingleAsteroidEphemerides(times, r_sun)
 

--- a/test/TPM_non-uniform_thermoparams/TPM_non-uniform_thermoparams.jl
+++ b/test/TPM_non-uniform_thermoparams/TPM_non-uniform_thermoparams.jl
@@ -63,7 +63,8 @@ Based on TPM_Ryugu test but with varying thermophysical properties.
     et_range = range(et_begin, et_end; length=n_step_in_cycle*n_cycle+1)
 
     times = collect(et_range)
-    r_sun = [SVector{3}(SPICE.spkpos("SUN", et, "RYUGU_FIXED", "None", "RYUGU")[1]) * 1000 for et in et_range]  # Sun's position in RYUGU_FIXED [m]
+    r_sun = [SPICE.spkpos("SUN", et, "RYUGU_FIXED", "None", "RYUGU")[1] for et in et_range]  # Sun's position in RYUGU_FIXED [km]
+    r_sun .*= 1000  # Convert [km] to [m]
 
     ephem = SingleAsteroidEphemerides(times, r_sun)
 

--- a/test/test_ephem_types.jl
+++ b/test/test_ephem_types.jl
@@ -74,6 +74,15 @@ Unit tests for parametric *Ephemerides{R} types introduced in v0.2.0:
         @test ephem.R_body_to_inertial === nothing
     end
 
+    @testset "SingleAsteroidEphemerides — SMatrix fast path (no allocation)" begin
+        # Passing Vector{SMatrix} directly hits the no-op fast path in _to_smat33_vec.
+        R_smat = [SMatrix{3,3,Float64,9}(I) for _ in 1:n]
+        ephem  = SingleAsteroidEphemerides(times, r_sun, R_smat)
+
+        @test eltype(ephem.R_body_to_inertial)  === SMatrix{3, 3, Float64, 9}
+        @test ephem.R_body_to_inertial          === R_smat  # same object: no copy
+    end
+
     @testset "SingleAsteroidEphemerides with rotation matrices" begin
         ephem = SingleAsteroidEphemerides(times, r_sun, R_body_to_inertial)
 

--- a/test/test_ephem_types.jl
+++ b/test/test_ephem_types.jl
@@ -3,7 +3,9 @@ test_ephem_types.jl
 
 Unit tests for parametric *Ephemerides{R} types introduced in v0.2.0:
 - Type hierarchy
-- Construction via convenience constructors
+- Construction via convenience constructors (plain Array input auto-converted)
+- Automatic element-type conversion to SVector{3,Float64} / SMatrix{3,3,Float64,9}
+- Explicit nothing constructor
 - Field access
 - Base.length
 - Inner constructor dimension validation
@@ -21,12 +23,13 @@ Unit tests for parametric *Ephemerides{R} types introduced in v0.2.0:
     n = 10
     au2m = AsteroidThermoPhysicalModels.au2m
 
+    # Plain Julia arrays — constructors auto-convert to SVector/SMatrix internally.
     times                  = collect(range(0.0, 100.0; length=n))
-    r_sun                  = [SVector{3, Float64}(au2m, 0, 0) for _ in 1:n]
-    r_secondary            = [SVector{3, Float64}(1e6, 0, 0)  for _ in 1:n]
-    R_body_to_inertial     = [SMatrix{3,3,Float64,9}(I) for _ in 1:n]
-    R_primary_to_secondary = [SMatrix{3,3,Float64,9}(I) for _ in 1:n]
-    R_primary_to_inertial  = [SMatrix{3,3,Float64,9}(I) for _ in 1:n]
+    r_sun                  = [[au2m, 0.0, 0.0] for _ in 1:n]
+    r_secondary            = [[1e6, 0.0, 0.0]  for _ in 1:n]
+    R_body_to_inertial     = [Matrix{Float64}(I, 3, 3) for _ in 1:n]
+    R_primary_to_secondary = [Matrix{Float64}(I, 3, 3) for _ in 1:n]
+    R_primary_to_inertial  = [Matrix{Float64}(I, 3, 3) for _ in 1:n]
 
     @testset "Type hierarchy" begin
         ephem_s  = SingleAsteroidEphemerides(times, r_sun)
@@ -55,21 +58,31 @@ Unit tests for parametric *Ephemerides{R} types introduced in v0.2.0:
         ephem = SingleAsteroidEphemerides(times, r_sun)
 
         @test ephem.times              === times
-        @test ephem.r_sun              === r_sun
+        @test ephem.r_sun              == r_sun
+        @test eltype(ephem.r_sun)      === SVector{3, Float64}
         @test ephem.R_body_to_inertial === nothing
-        @test length(ephem) == n
+        @test length(ephem)            == n
 
         # DimensionMismatch
         @test_throws DimensionMismatch SingleAsteroidEphemerides{Nothing}(times[1:end-1], r_sun, nothing)
     end
 
-    @testset "SingleAsteroidEphemerides{Vector{SMatrix}}" begin
+    @testset "SingleAsteroidEphemerides{Nothing} — explicit nothing" begin
+        ephem = SingleAsteroidEphemerides(times, r_sun, nothing)
+
+        @test ephem isa SingleAsteroidEphemerides{Nothing}
+        @test ephem.R_body_to_inertial === nothing
+    end
+
+    @testset "SingleAsteroidEphemerides with rotation matrices" begin
         ephem = SingleAsteroidEphemerides(times, r_sun, R_body_to_inertial)
 
-        @test ephem.times              === times
-        @test ephem.r_sun              === r_sun
-        @test ephem.R_body_to_inertial === R_body_to_inertial
-        @test length(ephem) == n
+        @test ephem.times                       === times
+        @test ephem.r_sun                       == r_sun
+        @test eltype(ephem.r_sun)               === SVector{3, Float64}
+        @test ephem.R_body_to_inertial          == R_body_to_inertial
+        @test eltype(ephem.R_body_to_inertial)  === SMatrix{3, 3, Float64, 9}
+        @test length(ephem)                     == n
 
         # DimensionMismatch
         @test_throws DimensionMismatch SingleAsteroidEphemerides(times, r_sun[1:end-1], R_body_to_inertial)
@@ -79,12 +92,15 @@ Unit tests for parametric *Ephemerides{R} types introduced in v0.2.0:
     @testset "BinaryAsteroidEphemerides{Nothing}" begin
         ephem = BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary)
 
-        @test ephem.times                  === times
-        @test ephem.r_sun                  === r_sun
-        @test ephem.r_secondary            === r_secondary
-        @test ephem.R_primary_to_secondary === R_primary_to_secondary
-        @test ephem.R_primary_to_inertial  === nothing
-        @test length(ephem) == n
+        @test ephem.times                          === times
+        @test ephem.r_sun                          == r_sun
+        @test eltype(ephem.r_sun)                  === SVector{3, Float64}
+        @test ephem.r_secondary                    == r_secondary
+        @test eltype(ephem.r_secondary)            === SVector{3, Float64}
+        @test ephem.R_primary_to_secondary         == R_primary_to_secondary
+        @test eltype(ephem.R_primary_to_secondary) === SMatrix{3, 3, Float64, 9}
+        @test ephem.R_primary_to_inertial          === nothing
+        @test length(ephem)                        == n
 
         # DimensionMismatch
         @test_throws DimensionMismatch BinaryAsteroidEphemerides{Nothing}(times[1:end-1], r_sun, r_secondary, R_primary_to_secondary, nothing)
@@ -93,15 +109,26 @@ Unit tests for parametric *Ephemerides{R} types introduced in v0.2.0:
         @test_throws DimensionMismatch BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary[1:end-1])
     end
 
-    @testset "BinaryAsteroidEphemerides{Vector{SMatrix}}" begin
+    @testset "BinaryAsteroidEphemerides{Nothing} — explicit nothing" begin
+        ephem = BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary, nothing)
+
+        @test ephem isa BinaryAsteroidEphemerides{Nothing}
+        @test ephem.R_primary_to_inertial === nothing
+    end
+
+    @testset "BinaryAsteroidEphemerides with rotation matrices" begin
         ephem = BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial)
 
-        @test ephem.times                  === times
-        @test ephem.r_sun                  === r_sun
-        @test ephem.r_secondary            === r_secondary
-        @test ephem.R_primary_to_secondary === R_primary_to_secondary
-        @test ephem.R_primary_to_inertial  === R_primary_to_inertial
-        @test length(ephem) == n
+        @test ephem.times                         === times
+        @test ephem.r_sun                         == r_sun
+        @test eltype(ephem.r_sun)                 === SVector{3, Float64}
+        @test ephem.r_secondary                   == r_secondary
+        @test eltype(ephem.r_secondary)           === SVector{3, Float64}
+        @test ephem.R_primary_to_secondary        == R_primary_to_secondary
+        @test eltype(ephem.R_primary_to_secondary) === SMatrix{3, 3, Float64, 9}
+        @test ephem.R_primary_to_inertial         == R_primary_to_inertial
+        @test eltype(ephem.R_primary_to_inertial) === SMatrix{3, 3, Float64, 9}
+        @test length(ephem)                       == n
 
         # DimensionMismatch
         @test_throws DimensionMismatch BinaryAsteroidEphemerides(times, r_sun[1:end-1], r_secondary, R_primary_to_secondary, R_primary_to_inertial)

--- a/test/test_output_spec.jl
+++ b/test/test_output_spec.jl
@@ -21,7 +21,7 @@ introduced in v0.2.0:
 
     n = 10
     times  = collect(range(0.0, 100.0; length=n))
-    r_sun  = [SVector{3, Float64}(au2m, 0, 0) for _ in 1:n]
+    r_sun  = [[au2m, 0.0, 0.0] for _ in 1:n]
     ephem  = SingleAsteroidEphemerides(times, r_sun)
 
     output_times        = times[end-2:end]
@@ -77,8 +77,8 @@ introduced in v0.2.0:
     end
 
     @testset "_validate_output_spec — valid binary (no error)" begin
-        r_secondary            = [SVector{3, Float64}(1e6, 0, 0) for _ in 1:n]
-        R_primary_to_secondary = [SMatrix{3,3,Float64,9}(I)      for _ in 1:n]
+        r_secondary            = [[1e6, 0.0, 0.0]          for _ in 1:n]
+        R_primary_to_secondary = [Matrix{Float64}(I, 3, 3) for _ in 1:n]
         ephem_b = BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary)
 
         output = BinaryAsteroidOutputSpec(
@@ -89,8 +89,8 @@ introduced in v0.2.0:
     end
 
     @testset "_validate_output_spec — invalid binary secondary (ArgumentError)" begin
-        r_secondary            = [SVector{3, Float64}(1e6, 0, 0) for _ in 1:n]
-        R_primary_to_secondary = [SMatrix{3,3,Float64,9}(I)      for _ in 1:n]
+        r_secondary            = [[1e6, 0.0, 0.0]          for _ in 1:n]
+        R_primary_to_secondary = [Matrix{Float64}(I, 3, 3) for _ in 1:n]
         ephem_b = BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary)
 
         invalid_time = times[end] + 1.0

--- a/test/test_problem_api.jl
+++ b/test/test_problem_api.jl
@@ -23,8 +23,8 @@ Unit tests for the Problem-Solver API introduced in v0.2.0:
 
     @testset "subsolar_temperature" begin
         au2m = AsteroidThermoPhysicalModels.au2m
-        r☉_1au  = SVector{3, Float64}(1 * au2m, 0, 0)
-        r☉_2au  = SVector{3, Float64}(2 * au2m, 0, 0)
+        r☉_1au  = [1 * au2m, 0.0, 0.0]
+        r☉_2au  = [2 * au2m, 0.0, 0.0]
 
         Tss_1au = subsolar_temperature(r☉_1au, 0.1, 0.9)
         Tss_2au = subsolar_temperature(r☉_2au, 0.1, 0.9)

--- a/test/test_tpm_with_force.jl
+++ b/test/test_tpm_with_force.jl
@@ -27,10 +27,10 @@ Covers: _alloc_solution (with forces/torques), record_timestep! (with R),
     times        = collect(et_range)
 
     # Rotation matrices: body-fixed rotates with period P around z-axis
-    R_b2i = [SMatrix{3,3,Float64,9}(RotZ(2π * et / P)) for et in et_range]
+    R_b2i = [RotZ(2π * et / P) for et in et_range]
 
     # Sun position in body-fixed frame (inverse rotation of inertial position)
-    r_sun = [SVector{3,Float64}(inv(RotZ(2π * et / P)) * SVector(au2m, 0.0, 0.0)) for et in et_range]
+    r_sun = [inv(RotZ(2π * et / P)) * SVector(au2m, 0.0, 0.0) for et in et_range]
 
     path_obj      = joinpath("shape", "icosahedron.obj")
     thermo_params = ThermoParams(0.1, 1000.0, 600.0, 0.1, 0.0, 0.9, 0.1, 0.01, 5)
@@ -119,8 +119,8 @@ Covers: _alloc_solution (with forces/torques), record_timestep! (with R),
     @testset "Binary asteroid — {<:AbstractVector}" begin
         DIR_OUTPUT = mktempdir()
 
-        r_secondary            = [SVector{3,Float64}(1e4, 0, 0) for _ in et_range]
-        R_primary_to_secondary = [SMatrix{3,3,Float64,9}(I)     for _ in et_range]
+        r_secondary            = [[1e4, 0.0, 0.0]          for _ in et_range]
+        R_primary_to_secondary = [Matrix{Float64}(I, 3, 3) for _ in et_range]
         R_primary_to_inertial  = R_b2i
 
         ephem = BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary, R_primary_to_inertial)


### PR DESCRIPTION
## Summary

- Add `_to_svec3_vec` / `_to_smat33_vec` helpers to auto-convert plain `Vector{Float64}` / `Matrix{Float64}` elements to the required `SVector{3,Float64}` / `SMatrix{3,3,Float64,9}` types, so users no longer need to import StaticArrays
- Add explicit `::Nothing` outer constructor overloads for `SingleAsteroidEphemerides` and `BinaryAsteroidEphemerides` to avoid a `MethodError` when `nothing` is passed explicitly to the 3- / 5-argument form
- Update all test files to use plain Array inputs, removing redundant `SVector{3}(...)` / `SMatrix{3,3,Float64,9}(...)` / `RotMatrix{3}(...)` wrappers; integration tests now serve as clean sample code
- Add `eltype` checks and explicit-`nothing` testsets to `test_ephem_types.jl`

## Test plan

- [x] `Ephemerides types`: 57 tests pass (up from 43), including new testsets for explicit `nothing` and element-type verification
- [x] `OutputSpec types`, `Problem API`, `TPM with force/torque`: all pass with plain Array inputs
- [x] CI green on all other test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)