### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-06-26
+
+No migration required from v0.2.0.
+
+### Added
+
+- `*Ephemerides` constructors now accept `AbstractRange` for `times` (e.g. `range(et_begin, et_end; length=n)`); the range is collected to `Vector{Float64}` internally, eliminating the manual `collect` call
+- `*Ephemerides` constructors now auto-convert plain `Vector` inputs to `Vector{SVector{3,Float64}}` for position vectors and `Vector{SMatrix{3,3,Float64,9}}` for rotation matrices; no need to import `StaticArrays` at the call site
+
+### Internal
+
+- Renamed `energy_in` / `energy_out` fields to `absorbed_power` / `emitted_power` in the diagnostics data — aligns the implementation with the documented names; these fields are not exported
+
 ## [0.2.0] - 2026-06-24
 
 This release introduces a Problem-Solver API redesign inspired by `DifferentialEquations.jl`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AsteroidThermoPhysicalModels"
 uuid = "ab46f4a3-3c83-4d86-98d6-41a8b1a2e76e"
 authors = ["Masanori Kanamaru"]
-version = "0.2.1-DEV"
+version = "0.2.1"
 
 [deps]
 AsteroidShapeModels = "a7943d8e-5d65-4248-ae23-0082f5115a05"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,14 @@ pkg> add AsteroidThermoPhysicalModels
 - **Yarkovsky Effect**: Orbital perturbation due to asymmetric thermal emission
 - **YORP Effect**: Rotational perturbation due to asymmetric thermal emission
 
-## 🆕 What's New in v0.2.0
+## 🆕 What's New in v0.2.x
+
+### v0.2.1
+
+- `*Ephemerides` constructors now accept `AbstractRange` for `times` — no need to call `collect` beforehand
+- `*Ephemerides` constructors now auto-convert plain arrays to `SVector`/`SMatrix` — no need to import `StaticArrays`
+
+### v0.2.0
 
 This release introduces a **Problem-Solver API** inspired by `DifferentialEquations.jl`, replacing the old `run_TPM!` function.
 
@@ -87,45 +94,60 @@ Temperature distribution of asteroid Didymos and its satellite Dimorphos:
 
 ## 📖 Basic Usage
 
+The workflow follows a **Problem → Solve → Export** pattern.
+
 ```julia
 using AsteroidShapeModels
 using AsteroidThermoPhysicalModels
 
+# --- Shape model ---
+shape = load_shape_obj("path/to/shape.obj"; scale=1000, with_face_visibility=true, with_bvh=true)
 
-# Load an asteroid shape model
-# - `path/to/shape.obj` is the path to your OBJ file (mandatory)
-# - `scale` : scale factor for the shape model (e.g., 1000 for km to m conversion)
-shape = load_shape_obj("path/to/shape.obj"; scale=1000)
+# --- Ephemerides ---
+# `times`  : epochs [s], any AbstractRange or Vector{Float64}
+# `r_sun`  : Sun position in body-fixed frame [m], Vector of length-3 arrays
+#   (typically computed from SPICE kernels — see integration test examples)
+ephem = SingleAsteroidEphemerides(times, r_sun)
 
-# Set thermal parameters
-thermo_params = ThermoParams(
-    8.0 * 3600,  # Rotation period [s]
-    0.05,        # Thermal skin depth [m]
-    200.0,       # Thermal inertia [J m⁻² K⁻¹ s⁻¹/²]
-    0.1,         # Reflectance in visible light [-]
-    0.0,         # Reflectance in thermal infrared [-]
-    0.9,         # Emissivity [-]
-    0.5,         # Depth of lower boundary [m]
-    0.0125,      # Depth step width [m]
-    41           # Number of depth steps
+# --- Thermal parameters ---
+k     = 0.1    # Thermal conductivity [W/m/K]
+ρ     = 1270.0 # Density [kg/m³]
+Cₚ    = 600.0  # Heat capacity [J/kg/K]
+R_vis = 0.04   # Reflectance in visible light [-]
+R_ir  = 0.0    # Reflectance in thermal infrared [-]
+ε     = 1.0    # Emissivity [-]
+z_max   = 0.6  # Lower boundary depth [m]
+n_depth = 61   # Number of depth nodes
+Δz      = z_max / (n_depth - 1)
+
+thermo_params = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
+
+# --- Problem definition ---
+problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
+    with_self_shadowing      = true,
+    with_self_heating        = true,
+    upper_boundary_condition = RadiationBoundaryCondition(),
+    lower_boundary_condition = InsulationBoundaryCondition(),
 )
 
-# Create TPM model with solver selection
-stpm = SingleAsteroidTPM(shape, thermo_params;
-    SELF_SHADOWING = true,
-    SELF_HEATING   = true,
-    SOLVER         = CrankNicolsonSolver(thermo_params),  # Choose solver
-    BC_UPPER       = RadiationBoundaryCondition(),
-    BC_LOWER       = InsulationBoundaryCondition()
+# --- Output specification ---
+output_times        = ephem.times[end-119:end]  # final rotation period
+subsurface_face_ids = [1, 2, 3]                 # faces for saving subsurface temperature profiles
+output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids)
+
+# --- Solve ---
+solution = solve(problem, CrankNicolson();
+    ephem               = ephem,
+    output              = output,
+    initial_temperature = 200.0,  # [K]
 )
 
-# Available solvers:
-# - ExplicitEulerSolver(thermo_params)   # Fast but requires small time steps
-# - ImplicitEulerSolver(thermo_params)   # Stable for any time step
-# - CrankNicolsonSolver(thermo_params)   # Best accuracy
-
-# Run simulation - see documentation for complete examples
+# --- Export results ---
+export_solution("output/", solution)
+# Writes: diagnostics.csv, surface_temperature.csv, subsurface_temperature.csv
 ```
+
+For a complete end-to-end example with SPICE ephemerides, see [test/TPM_Ryugu/TPM_Ryugu.jl](test/TPM_Ryugu/TPM_Ryugu.jl).
 
 ## 📊 Output
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,17 +82,20 @@ Redesign the API around a Problem-Solver pattern inspired by `DifferentialEquati
 **↓ Planned Releases ↓**
 ---
 
-## v0.2.1 - Patch Fixes (Target: 2026)
+## v0.2.1 - Patch Fixes (Released: 2026-06-26)
 
 Non-breaking fixes and convenience improvements before the v0.3.0 surface roughness work.
 
-- [ ] **Rename internal `energy_in` / `energy_out`** to `absorbed_power` / `emitted_power` — current names are physically inaccurate (units are W, not J); not exported so no breaking change
+- [x] **Rename internal `energy_in` / `energy_out`** to `absorbed_power` / `emitted_power` — current names are physically inaccurate (units are W, not J); not exported so no breaking change
 - [x] **`*Ephemerides` convenience constructors** — `times` accepts any `AbstractRange` (e.g. `range(et_begin, et_end; length=n)`) and is automatically collected to `Vector{Float64}`, eliminating the separate `collect` call; purely additive
-- [ ] **Test prefix cleanup** — remove unnecessary `AsteroidThermoPhysicalModels.` prefixes from exported symbols in test files
+- [x] **`*Ephemerides` auto-conversion** — constructors accept plain `Vector` inputs for position and rotation fields and convert to `SVector`/`SMatrix` internally; no need to import `StaticArrays` at the call site
+- [x] **Test prefix cleanup** — remove unnecessary `AsteroidThermoPhysicalModels.` prefixes from exported symbols in test files
 
-## v0.3.0 - Surface Roughness Support (Target: 2026)
+## v0.3.0 - Surface Roughness Support + ThermoParams Redesign (Target: 2026)
 
-Introduce thermophysical modeling of surface roughness using `HierarchicalShapeModel` from `AsteroidShapeModels.jl`, built on the clean Problem-Solver architecture established in v0.2.0. Each global face can optionally carry a roughness model, and an independent mini-TPM is run on its sub-faces (Full Sub-facet TPM). This is the most physically accurate approach and provides a basis for validating simpler approximations in the future.
+Introduce thermophysical modeling of surface roughness using `HierarchicalShapeModel` from `AsteroidShapeModels.jl`. This release also redesigns `ThermoParams` to separate material properties from numerical grid settings — a prerequisite for clean per-face material access in the roughness model.
+
+- [ ] **`ThermoParams` / `GridParams` redesign** (breaking): `ThermoParams` holds material properties only; new `GridParams` holds numerical grid settings; problem constructor expands scalar input to per-face `Vector{ThermoParams}` at construction time
 
 - [ ] **Roughness-aware problem type**: extend the problem type to accept `HierarchicalShapeModel` and hold independent sub-face state (illumination, flux, temperature, thermal force) for each face
 


### PR DESCRIPTION
## Summary

- Bump version to 0.2.1
- Update CHANGELOG.md with v0.2.1 entries
- Update ROADMAP.md: mark v0.2.1 tasks complete, add v0.3.0 ThermoParams redesign plan
- Update README.md: rewrite Basic Usage section to reflect v0.2.x API; add v0.2.1 patch notes to What's New

## Changes in v0.2.1

- `*Ephemerides` constructors now accept `AbstractRange` for `times` (PR #215)
- `*Ephemerides` constructors auto-convert plain arrays to `SVector`/`SMatrix` (PR #214)
- Internal: renamed `energy_in`/`energy_out` to `absorbed_power`/`emitted_power` (PR #212)
- Internal: test prefix cleanup (PR #213)

No migration required from v0.2.0.

## Test plan

- [x] CI passes on this branch
- [x] Version in `Project.toml` is `0.2.1`
- [x] `## [0.2.1]` section present in `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)