### PR TITLE
feat: separate `ThermoParams`/`GridParams` for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,98 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - TBD
+
+This release separates thermophysical material properties (`ThermoParams`) from
+numerical grid configuration (`GridParams`). The old monolithic `ThermoParams` that
+held both material and grid parameters is replaced by two focused types.
+
+### Migration Guide
+
+```julia
+# v0.2.x
+thermo_params = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
+problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params; ...)
+
+# v0.3.0 — material and grid parameters are now separate
+thermo_params = ThermoParams(
+    conductivity    = k,
+    density         = ρ,
+    heat_capacity   = Cₚ,
+    reflectance_vis = R_vis,
+    reflectance_ir  = R_ir,
+    emissivity      = ε,
+)
+grid_params = GridParams(; z_max=z_max, n_depth=n_depth)  # Δz is auto-computed
+problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params; ...)
+```
+
+For binary asteroid problems:
+
+```julia
+# v0.2.x
+problem = BinaryAsteroidThermoPhysicalProblem(
+    (shape1, shape2),
+    (thermo_params1, thermo_params2);
+    ...
+)
+
+# v0.3.0 — grid_params is now a required third positional argument
+problem = BinaryAsteroidThermoPhysicalProblem(
+    (shape1, shape2),
+    (thermo_params1, thermo_params2),
+    (grid_params1, grid_params2);
+    ...
+)
+# Or pass a single shared instance for both bodies:
+problem = BinaryAsteroidThermoPhysicalProblem(
+    (shape1, shape2),
+    thermo_params,
+    grid_params;
+    ...
+)
+```
+
+For code that reads fields of `ThermoParams`:
+
+```julia
+# v0.2.x
+thermo_params.thermal_conductivity  # Vector{Float64}
+thermo_params.n_depth               # Int
+thermo_params.Δz                    # Float64
+
+# v0.3.0
+thermo_params.conductivity  # renamed field
+grid_params.n_depth
+grid_params.Δz
+```
+
+### Added
+
+- **`GridParams`** struct for numerical depth-grid configuration, extracted from the
+  old monolithic `ThermoParams`:
+  - Fields: `z_max` (depth of lower boundary [m]), `n_depth` (number of depth nodes), `Δz` (node spacing [m])
+  - `GridParams(; z_max, n_depth)` keyword constructor: `Δz` is auto-computed as `z_max / (n_depth - 1)`, placing nodes uniformly at `0, Δz, 2Δz, …, z_max`; use the positional constructor `GridParams(z_max, n_depth, Δz)` to specify `Δz` explicitly
+  - `GridParams` is now exported
+- **`ThermoParams` keyword constructor** `ThermoParams(; conductivity, density, heat_capacity, reflectance_vis, reflectance_ir, emissivity)`: avoids relying on positional argument order
+- **`ThermoParams` mixed scalar/vector constructor**: scalar arguments are automatically broadcast to match the length of any vector arguments, removing the need for manual `fill()` calls in non-uniform surface cases
+
+### Changed
+
+- **Breaking**: `ThermoParams` no longer holds grid parameters (`z_max`, `Δz`, `n_depth`); pass a `GridParams` instance separately
+- **Breaking**: `ThermoParams.thermal_conductivity` renamed to `ThermoParams.conductivity`
+- **Breaking**: Positional 9-argument constructor `ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)` removed; use `ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε)` (6-arg) or the keyword constructor
+- **Breaking**: `SingleAsteroidThermoPhysicalProblem(shape, thermo_params; ...)` → `SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params; ...)`
+- **Breaking**: `BinaryAsteroidThermoPhysicalProblem((shape1, shape2), (tp1, tp2); ...)` → `BinaryAsteroidThermoPhysicalProblem((shape1, shape2), (tp1, tp2), (gp1, gp2); ...)`; a single `ThermoParams`/`GridParams` instance (non-tuple) can be shared between both bodies
+
+### Removed
+
+- **Breaking**: `broadcast_thermo_params!` removed; single-body `ThermoParams` (length-1 vectors) are now expanded to `n_face` at `SingleAsteroidThermoPhysicalProblem` construction time via an internal `_expand_thermo_params` call, eliminating the need for mutation
+
+### Internal
+
+- Moved `GridParams` definition to `src/grid_params.jl`
+
 ## [0.2.1] - 2026-06-26
 
 No migration required from v0.2.0.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,7 +95,7 @@ Non-breaking fixes and convenience improvements before the v0.3.0 surface roughn
 
 Introduce thermophysical modeling of surface roughness using `HierarchicalShapeModel` from `AsteroidShapeModels.jl`. This release also redesigns `ThermoParams` to separate material properties from numerical grid settings — a prerequisite for clean per-face material access in the roughness model.
 
-- [ ] **`ThermoParams` / `GridParams` redesign** (breaking): `ThermoParams` holds material properties only; new `GridParams` holds numerical grid settings; problem constructor expands scalar input to per-face `Vector{ThermoParams}` at construction time
+- [x] **`ThermoParams` / `GridParams` redesign** (breaking) — PR #218: `ThermoParams` holds material properties only; new `GridParams` holds depth-grid settings (`z_max`, `n_depth`, `Δz`); both types gain keyword-argument constructors; `ThermoParams` supports mixed scalar/vector input for non-uniform surfaces
 
 - [ ] **Roughness-aware problem type**: extend the problem type to accept `HierarchicalShapeModel` and hold independent sub-face state (illumination, flux, temperature, thermal force) for each face
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,7 +95,7 @@ Non-breaking fixes and convenience improvements before the v0.3.0 surface roughn
 
 Introduce thermophysical modeling of surface roughness using `HierarchicalShapeModel` from `AsteroidShapeModels.jl`. This release also redesigns `ThermoParams` to separate material properties from numerical grid settings — a prerequisite for clean per-face material access in the roughness model.
 
-- [x] **`ThermoParams` / `GridParams` redesign** (breaking) — PR #218: `ThermoParams` holds material properties only; new `GridParams` holds depth-grid settings (`z_max`, `n_depth`, `Δz`); both types gain keyword-argument constructors; `ThermoParams` supports mixed scalar/vector input for non-uniform surfaces
+- [x] **`ThermoParams` / `GridParams` redesign** (breaking) — PR #218: separate thermophysical material properties (`ThermoParams`) from numerical depth-grid settings (`GridParams`)
 
 - [ ] **Roughness-aware problem type**: extend the problem type to accept `HierarchicalShapeModel` and hold independent sub-face state (illumination, flux, temperature, thermal force) for each face
 

--- a/src/AsteroidThermoPhysicalModels.jl
+++ b/src/AsteroidThermoPhysicalModels.jl
@@ -46,6 +46,9 @@ export SingleAsteroidEphemerides
 export AbstractBinaryAsteroidEphemerides
 export BinaryAsteroidEphemerides
 
+include("grid_params.jl")
+export GridParams
+
 include("thermo_params.jl")
 export ThermoParams
 export thermal_skin_depth, thermal_inertia, subsolar_temperature

--- a/src/grid_params.jl
+++ b/src/grid_params.jl
@@ -1,0 +1,26 @@
+#=
+grid_params.jl
+
+Numerical grid settings for 1D heat conduction.
+=#
+
+"""
+    struct GridParams
+
+Numerical grid settings for the 1D heat conduction equation,
+shared across all facets.
+
+# Fields
+- `z_max`   : Depth of the lower boundary [m]
+- `Δz`      : Depth step width [m]
+- `n_depth` : Number of depth nodes
+
+# Notes
+Currently assumes a uniform depth grid. Variable-spacing support (e.g., finer
+near the surface) is planned for a future version.
+"""
+struct GridParams
+    z_max   ::Float64
+    Δz      ::Float64
+    n_depth ::Int
+end

--- a/src/grid_params.jl
+++ b/src/grid_params.jl
@@ -12,8 +12,8 @@ shared across all facets.
 
 # Fields
 - `z_max`   : Depth of the lower boundary [m]
-- `Δz`      : Depth step width [m]
 - `n_depth` : Number of depth nodes
+- `Δz`      : Depth step width [m]
 
 # Notes
 Currently assumes a uniform depth grid. Variable-spacing support (e.g., finer
@@ -21,6 +21,22 @@ near the surface) is planned for a future version.
 """
 struct GridParams
     z_max   ::Float64
-    Δz      ::Float64
     n_depth ::Int
+    Δz      ::Float64
 end
+
+"""
+    GridParams(; z_max, n_depth)
+
+Construct `GridParams` from keyword arguments, with `Δz` computed automatically as
+`z_max / (n_depth - 1)`, placing nodes uniformly at `0, Δz, 2Δz, …, z_max`.
+
+# Keyword Arguments
+- `z_max`   : Depth of the lower boundary [m]
+- `n_depth` : Number of depth nodes
+
+# Notes
+To specify `Δz` explicitly (advanced use), use the positional constructor
+`GridParams(z_max, n_depth, Δz)`.
+"""
+GridParams(; z_max, n_depth) = GridParams(z_max, n_depth, z_max / (n_depth - 1))

--- a/src/heat_conduction.jl
+++ b/src/heat_conduction.jl
@@ -40,7 +40,7 @@ where:
 - F_rad : Thermal radiation flux from surrounding surfaces
 
 # Notes
-- This function is called when `state.problem.thermo_params.thermal_conductivity` is zero
+- This function is called when `state.problem.thermo_params.conductivity` is zero
 - The temperature instantly adjusts to balance incoming and outgoing radiation
 - No subsurface temperatures are updated (only surface layer)
 """
@@ -93,7 +93,7 @@ where α = k/(ρCₚ) is the thermal diffusivity.
 """
 function update_temperature!(state::SingleAsteroidThermoPhysicalState, Δt)
     # Handle zero-conductivity case
-    if iszero(state.problem.thermo_params.thermal_conductivity)
+    if iszero(state.problem.thermo_params.conductivity)
         update_temperature_zero_conductivity!(state)
         return
     end
@@ -175,10 +175,10 @@ function explicit_euler!(state::SingleAsteroidThermoPhysicalState, Δt)
     n_face = size(T, 2)
 
     for i_face in 1:n_face
-        k  = state.problem.thermo_params.thermal_conductivity[i_face]
+        k  = state.problem.thermo_params.conductivity[i_face]
         ρ  = state.problem.thermo_params.density[i_face]
         Cₚ = state.problem.thermo_params.heat_capacity[i_face]
-        Δz = state.problem.thermo_params.Δz
+        Δz = state.problem.grid_params.Δz
 
         α = thermal_diffusivity(k, ρ, Cₚ)  # Thermal diffusivity [m²/s]
         λ = α * Δt / Δz^2
@@ -248,10 +248,10 @@ function implicit_euler!(state::SingleAsteroidThermoPhysicalState, Δt)
     n_face = size(T, 2)
 
     for i_face in 1:n_face
-        k  = state.problem.thermo_params.thermal_conductivity[i_face]
+        k  = state.problem.thermo_params.conductivity[i_face]
         ρ  = state.problem.thermo_params.density[i_face]
         Cₚ = state.problem.thermo_params.heat_capacity[i_face]
-        Δz = state.problem.thermo_params.Δz
+        Δz = state.problem.grid_params.Δz
 
         α = thermal_diffusivity(k, ρ, Cₚ)  # Thermal diffusivity [m²/s]
         λ = α * Δt / Δz^2
@@ -369,10 +369,10 @@ function crank_nicolson!(state::SingleAsteroidThermoPhysicalState, Δt)
     n_face = size(T, 2)
 
     for i_face in 1:n_face
-        k  = state.problem.thermo_params.thermal_conductivity[i_face]
+        k  = state.problem.thermo_params.conductivity[i_face]
         ρ  = state.problem.thermo_params.density[i_face]
         Cₚ = state.problem.thermo_params.heat_capacity[i_face]
-        Δz = state.problem.thermo_params.Δz
+        Δz = state.problem.grid_params.Δz
 
         α = thermal_diffusivity(k, ρ, Cₚ)  # Thermal diffusivity [m²/s]
         r = α * Δt / (2 * Δz^2)
@@ -499,13 +499,13 @@ function update_upper_temperature!(state::SingleAsteroidThermoPhysicalState, i::
 
     #### Radiation boundary condition ####
     if state.problem.upper_boundary_condition isa RadiationBoundaryCondition
-        k     = state.problem.thermo_params.thermal_conductivity[i]
+        k     = state.problem.thermo_params.conductivity[i]
         ρ     = state.problem.thermo_params.density[i]
         Cₚ    = state.problem.thermo_params.heat_capacity[i]
         R_vis = state.problem.thermo_params.reflectance_vis[i]
         R_ir  = state.problem.thermo_params.reflectance_ir[i]
         ε     = state.problem.thermo_params.emissivity[i]
-        Δz    = state.problem.thermo_params.Δz
+        Δz    = state.problem.grid_params.Δz
     
         F_sun = state.flux_sun[i]
         F_scat = state.flux_scat[i]

--- a/src/solver_types.jl
+++ b/src/solver_types.jl
@@ -72,7 +72,7 @@ struct ExplicitEulerCache <: HeatConductionCache
     x::Vector{Float64}
 end
 
-ExplicitEulerCache(thermo_params::AbstractThermoParams) = ExplicitEulerCache(thermo_params.n_depth)
+ExplicitEulerCache(grid_params::GridParams) = ExplicitEulerCache(grid_params.n_depth)
 ExplicitEulerCache(N::Integer) = ExplicitEulerCache(zeros(N))
 
 
@@ -88,7 +88,7 @@ struct ImplicitEulerCache <: HeatConductionCache
     x::Vector{Float64}
 end
 
-ImplicitEulerCache(thermo_params::AbstractThermoParams) = ImplicitEulerCache(thermo_params.n_depth)
+ImplicitEulerCache(grid_params::GridParams) = ImplicitEulerCache(grid_params.n_depth)
 ImplicitEulerCache(N::Integer) = ImplicitEulerCache(zeros(N), zeros(N), zeros(N), zeros(N), zeros(N))
 
 
@@ -107,7 +107,7 @@ struct CrankNicolsonCache <: HeatConductionCache
     x::Vector{Float64}
 end
 
-CrankNicolsonCache(thermo_params::AbstractThermoParams) = CrankNicolsonCache(thermo_params.n_depth)
+CrankNicolsonCache(grid_params::GridParams) = CrankNicolsonCache(grid_params.n_depth)
 CrankNicolsonCache(N::Integer) = CrankNicolsonCache(zeros(N), zeros(N), zeros(N), zeros(N), zeros(N))
 
 

--- a/src/thermo_params.jl
+++ b/src/thermo_params.jl
@@ -113,9 +113,9 @@ abstract type AbstractThermoParams end
 
 Material thermal properties per facet.
 
-For a uniform surface, pass a single `ThermoParams` constructed from scalar values.
-For a non-uniform surface, pass a `ThermoParams` constructed from `Vector{Float64}` values
-of length `n_face`.
+Each field is a `Vector{Float64}` of length `n_face`.
+The outer constructor accepts `Float64` (uniform) or `Vector{Float64}` (non-uniform) per field,
+and scalar arguments are automatically broadcast to match any vector arguments.
 
 # Fields
 - `conductivity`    : Thermal conductivity for each facet [W/m/K]
@@ -138,7 +138,9 @@ end
 """
     ThermoParams(conductivity, density, heat_capacity, reflectance_vis, reflectance_ir, emissivity)
 
-Construct `ThermoParams` from scalar values (uniform surface).
+Construct `ThermoParams` from scalar or vector arguments, which may be freely mixed.
+`Float64` arguments are automatically broadcast to match the length of any `Vector{Float64}`
+arguments. All vector arguments must have the same length.
 
 # Arguments
 - `conductivity`    : Thermal conductivity [W/m/K]
@@ -147,16 +149,39 @@ Construct `ThermoParams` from scalar values (uniform surface).
 - `reflectance_vis` : Reflectance in visible light [-]
 - `reflectance_ir`  : Reflectance in thermal infrared [-]
 - `emissivity`      : Emissivity [-]
+
+# Examples
+```julia
+# Uniform surface (all scalars)
+ThermoParams(0.1, 1500.0, 800.0, 0.05, 0.0, 0.9)
+
+# Non-uniform conductivity only; other parameters are uniform
+ThermoParams(k_vec, 1500.0, 800.0, 0.05, 0.0, 0.9)
+
+# Fully non-uniform
+ThermoParams(k_vec, ρ_vec, Cₚ_vec, R_vis_vec, R_ir_vec, ε_vec)
+```
 """
 function ThermoParams(
-    conductivity    ::Float64,
-    density         ::Float64,
-    heat_capacity   ::Float64,
-    reflectance_vis ::Float64,
-    reflectance_ir  ::Float64,
-    emissivity      ::Float64,
+    conductivity    ::Union{Float64, Vector{Float64}},
+    density         ::Union{Float64, Vector{Float64}},
+    heat_capacity   ::Union{Float64, Vector{Float64}},
+    reflectance_vis ::Union{Float64, Vector{Float64}},
+    reflectance_ir  ::Union{Float64, Vector{Float64}},
+    emissivity      ::Union{Float64, Vector{Float64}},
 )
-    ThermoParams([conductivity], [density], [heat_capacity], [reflectance_vis], [reflectance_ir], [emissivity])
+    args = (conductivity, density, heat_capacity, reflectance_vis, reflectance_ir, emissivity)
+    lengths = [length(a) for a in args if a isa Vector{Float64}]
+    n = isempty(lengths) ? 1 : first(lengths)
+    all(==(n), lengths) || throw(ArgumentError(
+        "ThermoParams vector arguments must all have the same length, got: $lengths"
+    ))
+    expand(x::Float64)         = fill(x, n)
+    expand(x::Vector{Float64}) = x
+    ThermoParams(
+        expand(conductivity), expand(density), expand(heat_capacity),
+        expand(reflectance_vis), expand(reflectance_ir), expand(emissivity),
+    )
 end
 
 
@@ -164,7 +189,8 @@ end
     ThermoParams(; conductivity, density, heat_capacity, reflectance_vis, reflectance_ir, emissivity)
 
 Construct `ThermoParams` from keyword arguments.
-Accepts the same types as the positional constructors (scalar `Float64` or `Vector{Float64}`).
+Each argument can be a `Float64` (uniform) or `Vector{Float64}` (non-uniform),
+and scalar/vector arguments may be freely mixed.
 
 # Keyword Arguments
 - `conductivity`    : Thermal conductivity [W/m/K]

--- a/src/thermo_params.jl
+++ b/src/thermo_params.jl
@@ -161,24 +161,6 @@ end
 
 
 """
-    struct GridParams
-
-Numerical grid settings for the 1D heat conduction equation,
-shared across all facets and sub-facets.
-
-# Fields
-- `z_max`   : Depth of the lower boundary [m]
-- `Δz`      : Depth step width [m]
-- `n_depth` : Number of depth nodes
-"""
-struct GridParams
-    z_max   ::Float64
-    Δz      ::Float64
-    n_depth ::Int
-end
-
-
-"""
     subsolar_temperature(r☉, R_vis, ε) -> Tₛₛ
 
 Calculate the subsolar equilibrium temperature at a given heliocentric distance.

--- a/src/thermo_params.jl
+++ b/src/thermo_params.jl
@@ -161,6 +161,32 @@ end
 
 
 """
+    ThermoParams(; conductivity, density, heat_capacity, reflectance_vis, reflectance_ir, emissivity)
+
+Construct `ThermoParams` from keyword arguments.
+Accepts the same types as the positional constructors (scalar `Float64` or `Vector{Float64}`).
+
+# Keyword Arguments
+- `conductivity`    : Thermal conductivity [W/m/K]
+- `density`         : Density [kg/m³]
+- `heat_capacity`   : Heat capacity [J/kg/K]
+- `reflectance_vis` : Reflectance in visible light [-]
+- `reflectance_ir`  : Reflectance in thermal infrared [-]
+- `emissivity`      : Emissivity [-]
+"""
+function ThermoParams(;
+    conductivity,
+    density,
+    heat_capacity,
+    reflectance_vis,
+    reflectance_ir,
+    emissivity,
+)
+    ThermoParams(conductivity, density, heat_capacity, reflectance_vis, reflectance_ir, emissivity)
+end
+
+
+"""
     subsolar_temperature(r☉, R_vis, ε) -> Tₛₛ
 
 Calculate the subsolar equilibrium temperature at a given heliocentric distance.

--- a/src/thermo_params.jl
+++ b/src/thermo_params.jl
@@ -109,78 +109,72 @@ thermal_diffusivity(k, ρ, Cₚ) = @. k / (ρ * Cₚ)
 abstract type AbstractThermoParams end
 
 """
-    struct ThermoParams
+    struct ThermoParams <: AbstractThermoParams
+
+Material thermal properties per facet.
+
+For a uniform surface, pass a single `ThermoParams` constructed from scalar values.
+For a non-uniform surface, pass a `ThermoParams` constructed from `Vector{Float64}` values
+of length `n_face`.
 
 # Fields
-- `thermal_conductivity` : Vector of thermal conductivity for each facet [W/m/K]
-- `density`              : Vector of density for each facet [kg/m³]
-- `heat_capacity`        : Vector of heat capacity for each facet [J/kg/K]
-
-- `reflectance_vis` : Vector of reflectance in visible light for each facet [-]
-- `reflectance_ir`  : Vector of reflectance in thermal infrared for each facet [-]
-- `emissivity`      : Vector of emissivity for each facet [-]
-
-- `z_max`   : Depth of the lower boundary of a heat conduction equation [m]
-- `Δz`      : Depth step width [m]
-- `n_depth` : Number of depth steps
+- `conductivity`    : Thermal conductivity for each facet [W/m/K]
+- `density`         : Density for each facet [kg/m³]
+- `heat_capacity`   : Heat capacity for each facet [J/kg/K]
+- `reflectance_vis` : Reflectance in visible light for each facet [-]
+- `reflectance_ir`  : Reflectance in thermal infrared for each facet [-]
+- `emissivity`      : Emissivity for each facet [-]
 """
 struct ThermoParams <: AbstractThermoParams
-    thermal_conductivity ::Vector{Float64}
-    density              ::Vector{Float64}
-    heat_capacity        ::Vector{Float64}
-
+    conductivity    ::Vector{Float64}
+    density         ::Vector{Float64}
+    heat_capacity   ::Vector{Float64}
     reflectance_vis ::Vector{Float64}
     reflectance_ir  ::Vector{Float64}
     emissivity      ::Vector{Float64}
-
-    z_max   ::Float64
-    Δz      ::Float64
-    n_depth ::Int
 end
 
 
 """
-    ThermoParams(
-        thermal_conductivity ::Float64,
-        density              ::Float64,
-        heat_capacity        ::Float64,
-        reflectance_vis      ::Float64,
-        reflectance_ir       ::Float64,
-        emissivity           ::Float64,
-        z_max                ::Float64,
-        Δz                   ::Float64,
-        n_depth              ::Int
-    )
+    ThermoParams(conductivity, density, heat_capacity, reflectance_vis, reflectance_ir, emissivity)
 
-Outer constructor for `ThermoParams`.
-You can give the same parameters to all facets by `Float64`.
+Construct `ThermoParams` from scalar values (uniform surface).
 
 # Arguments
-- `thermal_conductivity` : Thermal conductivity [W/m/K]
-- `density`              : Density [kg/m³]
-- `heat_capacity`        : Heat capacity [J/kg/K]
-
+- `conductivity`    : Thermal conductivity [W/m/K]
+- `density`         : Density [kg/m³]
+- `heat_capacity`   : Heat capacity [J/kg/K]
 - `reflectance_vis` : Reflectance in visible light [-]
 - `reflectance_ir`  : Reflectance in thermal infrared [-]
 - `emissivity`      : Emissivity [-]
-
-- `z_max`           : Depth of the lower boundary of a heat conduction equation [m]
-- `Δz`              : Depth step width [m]
-- `n_depth`         : Number of depth steps
 """
 function ThermoParams(
-    thermal_conductivity ::Float64,
-    density              ::Float64,
-    heat_capacity        ::Float64,
-    reflectance_vis      ::Float64,
-    reflectance_ir       ::Float64,
-    emissivity           ::Float64,
-    z_max                ::Float64,
-    Δz                   ::Float64,
-    n_depth              ::Int
+    conductivity    ::Float64,
+    density         ::Float64,
+    heat_capacity   ::Float64,
+    reflectance_vis ::Float64,
+    reflectance_ir  ::Float64,
+    emissivity      ::Float64,
 )
+    ThermoParams([conductivity], [density], [heat_capacity], [reflectance_vis], [reflectance_ir], [emissivity])
+end
 
-    return ThermoParams([thermal_conductivity], [density], [heat_capacity], [reflectance_vis], [reflectance_ir], [emissivity], z_max, Δz, n_depth)
+
+"""
+    struct GridParams
+
+Numerical grid settings for the 1D heat conduction equation,
+shared across all facets and sub-facets.
+
+# Fields
+- `z_max`   : Depth of the lower boundary [m]
+- `Δz`      : Depth step width [m]
+- `n_depth` : Number of depth nodes
+"""
+struct GridParams
+    z_max   ::Float64
+    Δz      ::Float64
+    n_depth ::Int
 end
 
 

--- a/src/thermo_params.jl
+++ b/src/thermo_params.jl
@@ -186,6 +186,10 @@ function ThermoParams(;
 end
 
 
+# ╔═══════════════════════════════════════════════════════════════════╗
+# ║              Equilibrium temperature estimation                   ║
+# ╚═══════════════════════════════════════════════════════════════════╝
+
 """
     subsolar_temperature(r☉, R_vis, ε) -> Tₛₛ
 

--- a/src/tpm_problem.jl
+++ b/src/tpm_problem.jl
@@ -35,7 +35,7 @@ separate from the numerical method used to solve it.
 # Usage
 ```julia
 thermo_params = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε)
-grid_params   = GridParams(z_max, Δz, n_depth)
+grid_params   = GridParams(z_max, n_depth, Δz)
 problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params;
     with_self_shadowing = true,
     with_self_heating   = true,

--- a/src/tpm_problem.jl
+++ b/src/tpm_problem.jl
@@ -21,7 +21,8 @@ separate from the numerical method used to solve it.
 
 # Fields
 - `shape`                    : Shape model of the asteroid (`ShapeModel` or `HierarchicalShapeModel`)
-- `thermo_params`            : Thermophysical parameters
+- `thermo_params`            : Thermophysical material parameters (all vectors expanded to length `n_face`)
+- `grid_params`              : Numerical grid settings
 - `with_self_shadowing`      : Whether to include self-shadowing
 - `with_self_heating`        : Whether to include self-heating (re-absorption of thermal emission from other faces)
 - `upper_boundary_condition` : Boundary condition at the surface (upper boundary)
@@ -29,23 +30,25 @@ separate from the numerical method used to solve it.
 
 # Usage
 ```julia
-problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
+thermo_params = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε)
+grid_params   = GridParams(z_max, Δz, n_depth)
+problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params;
     with_self_shadowing = true,
     with_self_heating   = true,
     upper_boundary_condition = RadiationBoundaryCondition(),
     lower_boundary_condition = InsulationBoundaryCondition(),
 )
-solution = solve(problem, CrankNicolson(); ephem = ephem, T₀ = 200.0)
+solution = solve(problem, CrankNicolson(); ephem = ephem, initial_temperature = 200.0)
 ```
 """
 struct SingleAsteroidThermoPhysicalProblem{
     Sh <: AbstractShapeModel,
-    P  <: AbstractThermoParams,
     BU <: AbstractBoundaryCondition,
     BL <: AbstractBoundaryCondition,
 } <: AbstractThermoPhysicalProblem
     shape                    ::Sh
-    thermo_params            ::P
+    thermo_params            ::ThermoParams
+    grid_params              ::GridParams
     with_self_shadowing      ::Bool
     with_self_heating        ::Bool
     upper_boundary_condition ::BU
@@ -54,13 +57,39 @@ end
 
 
 """
-    SingleAsteroidThermoPhysicalProblem(shape, thermo_params; kwargs...) -> problem
+    _expand_thermo_params(thermo_params::ThermoParams, n_face::Int) -> ThermoParams
+
+Expand a `ThermoParams` with length-1 vectors to length `n_face` (uniform surface),
+or validate that all vectors already have length `n_face` (non-uniform surface).
+"""
+function _expand_thermo_params(thermo_params::ThermoParams, n_face::Int)
+    n = length(thermo_params.conductivity)
+    if n == 1
+        return ThermoParams(
+            fill(thermo_params.conductivity[1],    n_face),
+            fill(thermo_params.density[1],         n_face),
+            fill(thermo_params.heat_capacity[1],   n_face),
+            fill(thermo_params.reflectance_vis[1], n_face),
+            fill(thermo_params.reflectance_ir[1],  n_face),
+            fill(thermo_params.emissivity[1],      n_face),
+        )
+    elseif n == n_face
+        return thermo_params
+    else
+        throw(ArgumentError("ThermoParams vector length ($n) must be 1 (uniform) or n_face ($n_face)."))
+    end
+end
+
+
+"""
+    SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params; kwargs...) -> problem
 
 Construct a thermophysical problem for a single asteroid.
 
 # Arguments
 - `shape`         : Shape model of the asteroid
-- `thermo_params` : Thermophysical parameters
+- `thermo_params` : Thermophysical material parameters (`ThermoParams`)
+- `grid_params`   : Numerical grid settings (`GridParams`)
 
 # Keyword Arguments
 - `with_self_shadowing = true` : Whether to include self-shadowing
@@ -72,9 +101,9 @@ Construct a thermophysical problem for a single asteroid.
 - If `with_self_shadowing = true` and `face_visibility_graph` is not yet built, it is built automatically.
   To avoid this, pre-build with `build_face_visibility_graph!` or pass `with_face_visibility=true`
   when loading the shape.
-- Thermophysical parameters are broadcast to all faces via `broadcast_thermo_params!`.
+- `ThermoParams` with length-1 vectors is expanded to `n_face` at construction time.
 """
-function SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
+function SingleAsteroidThermoPhysicalProblem(shape, thermo_params::ThermoParams, grid_params::GridParams;
     with_self_shadowing ::Bool = true,
     with_self_heating   ::Bool = true,
     upper_boundary_condition   = RadiationBoundaryCondition(),
@@ -85,9 +114,10 @@ function SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
         build_face_visibility_graph!(shape)
     end
 
-    broadcast_thermo_params!(thermo_params, shape)
+    n_face = length(shape.faces)
+    thermo_params_expanded = _expand_thermo_params(thermo_params, n_face)
 
-    SingleAsteroidThermoPhysicalProblem(shape, thermo_params, with_self_shadowing, with_self_heating, upper_boundary_condition, lower_boundary_condition)
+    SingleAsteroidThermoPhysicalProblem(shape, thermo_params_expanded, grid_params, with_self_shadowing, with_self_heating, upper_boundary_condition, lower_boundary_condition)
 end
 
 
@@ -162,14 +192,19 @@ function BinaryAsteroidThermoPhysicalProblem(
 end
 
 
+_to_pair(x)        = (x, x)   # single value → apply to both bodies
+_to_pair(x::Tuple) = x        # Tuple → use as-is (element per body)
+
+
 """
-    BinaryAsteroidThermoPhysicalProblem(shape, thermo_params; kwargs...) -> problem
+    BinaryAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params; kwargs...) -> problem
 
 Convenience constructor: build both single-body problems from raw shapes and parameters.
 
 # Arguments
 - `shape`         : Tuple `(shape1, shape2)` of shape models
-- `thermo_params` : Tuple `(thermo_params1, thermo_params2)` of thermophysical parameters
+- `thermo_params` : `ThermoParams` applied to both bodies, or Tuple `(thermo_params1, thermo_params2)` for per-body settings
+- `grid_params`   : `GridParams` applied to both bodies, or Tuple `(grid_params1, grid_params2)` for per-body settings
 
 # Keyword Arguments
 Single-body kwargs (applied identically to both bodies):
@@ -188,9 +223,11 @@ separately and pass the results to `BinaryAsteroidThermoPhysicalProblem(primary,
 
 # Example
 ```julia
+grid_params = GridParams(z_max, Δz, n_depth)
 problem = BinaryAsteroidThermoPhysicalProblem(
     (shape1, shape2),
-    (thermo_params1, thermo_params2);
+    (thermo_params1, thermo_params2),
+    grid_params;
     with_mutual_shadowing = true,
     with_mutual_heating   = true,
 )
@@ -198,7 +235,8 @@ problem = BinaryAsteroidThermoPhysicalProblem(
 """
 function BinaryAsteroidThermoPhysicalProblem(
     shape         ::Tuple,
-    thermo_params ::Tuple;
+    thermo_params,
+    grid_params;
     with_self_shadowing ::Bool   = true,
     with_self_heating   ::Bool   = true,
     upper_boundary_condition     = RadiationBoundaryCondition(),
@@ -206,20 +244,23 @@ function BinaryAsteroidThermoPhysicalProblem(
     with_mutual_shadowing ::Bool = true,
     with_mutual_heating   ::Bool = true,
 )
-    prob1 = SingleAsteroidThermoPhysicalProblem(shape[1], thermo_params[1];
+    thermo_params1, thermo_params2 = _to_pair(thermo_params)
+    grid_params1, grid_params2 = _to_pair(grid_params)
+
+    prob1 = SingleAsteroidThermoPhysicalProblem(shape[1], thermo_params1, grid_params1;
         with_self_shadowing,
         with_self_heating,
         upper_boundary_condition,
         lower_boundary_condition,
     )
 
-    prob2 = SingleAsteroidThermoPhysicalProblem(shape[2], thermo_params[2];
+    prob2 = SingleAsteroidThermoPhysicalProblem(shape[2], thermo_params2, grid_params2;
         with_self_shadowing,
         with_self_heating,
         upper_boundary_condition,
         lower_boundary_condition,
     )
-    
+
     BinaryAsteroidThermoPhysicalProblem(prob1, prob2;
         with_mutual_shadowing,
         with_mutual_heating,

--- a/src/tpm_problem.jl
+++ b/src/tpm_problem.jl
@@ -12,6 +12,10 @@ Abstract type for thermophysical problem definitions.
 abstract type AbstractThermoPhysicalProblem end
 
 
+# ╔═══════════════════════════════════════════════════════════════════╗
+# ║              Single-asteroid thermophysical problem               ║
+# ╚═══════════════════════════════════════════════════════════════════╝
+
 """
     struct SingleAsteroidThermoPhysicalProblem
 
@@ -120,6 +124,10 @@ function SingleAsteroidThermoPhysicalProblem(shape, thermo_params::ThermoParams,
     SingleAsteroidThermoPhysicalProblem(shape, thermo_params_expanded, grid_params, with_self_shadowing, with_self_heating, upper_boundary_condition, lower_boundary_condition)
 end
 
+
+# ╔═══════════════════════════════════════════════════════════════════╗
+# ║               Binary-asteroid thermophysical problem              ║
+# ╚═══════════════════════════════════════════════════════════════════╝
 
 """
     struct BinaryAsteroidThermoPhysicalProblem
@@ -235,14 +243,14 @@ problem = BinaryAsteroidThermoPhysicalProblem(
 """
 function BinaryAsteroidThermoPhysicalProblem(
     shape         ::Tuple,
-    thermo_params,
-    grid_params;
-    with_self_shadowing ::Bool   = true,
-    with_self_heating   ::Bool   = true,
-    upper_boundary_condition     = RadiationBoundaryCondition(),
-    lower_boundary_condition     = InsulationBoundaryCondition(),
-    with_mutual_shadowing ::Bool = true,
-    with_mutual_heating   ::Bool = true,
+    thermo_params ::Union{Tuple, ThermoParams},
+    grid_params   ::Union{Tuple, GridParams};
+    with_self_shadowing::Bool   = true,
+    with_self_heating::Bool     = true,
+    upper_boundary_condition    = RadiationBoundaryCondition(),
+    lower_boundary_condition    = InsulationBoundaryCondition(),
+    with_mutual_shadowing::Bool = true,
+    with_mutual_heating::Bool   = true,
 )
     thermo_params1, thermo_params2 = _to_pair(thermo_params)
     grid_params1, grid_params2 = _to_pair(grid_params)

--- a/src/tpm_solution.jl
+++ b/src/tpm_solution.jl
@@ -261,12 +261,12 @@ function _build_single_solution(
     n_step  = length(times)
     n_save  = length(output.output_times)
     n_face  = length(state.problem.shape.faces)
-    n_depth = state.problem.thermo_params.n_depth
+    n_depth = state.problem.grid_params.n_depth
 
     absorbed_power = zeros(n_step)
     emitted_power  = zeros(n_step)
 
-    depth_nodes            = state.problem.thermo_params.Δz * collect(0:n_depth-1)
+    depth_nodes            = state.problem.grid_params.Δz * collect(0:n_depth-1)
     surface_temperature    = output.save_surface_temperature    ? zeros(n_face, n_save) : nothing
     subsurface_temperature = output.save_subsurface_temperature ? Dict{Int,Matrix{Float64}}(i => zeros(n_depth, n_save) for i in output.subsurface_face_ids) : nothing
     face_forces            = output.save_face_forces            ? zeros(SVector{3,Float64}, n_face, n_save) : nothing

--- a/src/tpm_solve.jl
+++ b/src/tpm_solve.jl
@@ -12,19 +12,18 @@ Internal dispatch:
 =#
 
 # Build the appropriate HeatConductionCache from an algorithm type
-_build_cache(::ExplicitEuler, thermo_params) = ExplicitEulerCache(thermo_params)
-_build_cache(::ImplicitEuler, thermo_params) = ImplicitEulerCache(thermo_params)
-_build_cache(::CrankNicolson, thermo_params) = CrankNicolsonCache(thermo_params)
+_build_cache(::ExplicitEuler, grid_params) = ExplicitEulerCache(grid_params)
+_build_cache(::ImplicitEuler, grid_params) = ImplicitEulerCache(grid_params)
+_build_cache(::CrankNicolson, grid_params) = CrankNicolsonCache(grid_params)
 
 
 # Internal helper: build SingleAsteroidThermoPhysicalState from a problem + algorithm.
-# broadcast_thermo_params! has already been called in the problem constructor.
 function _build_single_state(
     problem   ::SingleAsteroidThermoPhysicalProblem,
     algorithm ::AbstractThermoPhysicalAlgorithm,
 )
-    cache   = _build_cache(algorithm, problem.thermo_params)
-    n_depth = problem.thermo_params.n_depth
+    cache   = _build_cache(algorithm, problem.grid_params)
+    n_depth = problem.grid_params.n_depth
     n_face  = length(problem.shape.faces)
 
     SingleAsteroidThermoPhysicalState(

--- a/src/tpm_state.jl
+++ b/src/tpm_state.jl
@@ -11,49 +11,6 @@ Abstract type for asteroid thermophysical simulation state.
 abstract type AbstractAsteroidThermoPhysicalState end
 
 
-"""
-    broadcast_thermo_params!(thermo_params::ThermoParams, n_face::Int)
-
-Broadcast the thermophysical parameters to all faces if the values are uniform globally.
-
-# Arguments
-- `thermo_params` : Thermophysical parameters
-- `n_face`        : Number of faces on the shape model
-"""
-function broadcast_thermo_params!(thermo_params::ThermoParams, n_face::Int)
-    if length(thermo_params.thermal_conductivity) == 1
-        resize!(thermo_params.thermal_conductivity, n_face)
-        resize!(thermo_params.density,              n_face)
-        resize!(thermo_params.heat_capacity,        n_face)
-        resize!(thermo_params.reflectance_vis,      n_face)
-        resize!(thermo_params.reflectance_ir,       n_face)
-        resize!(thermo_params.emissivity,           n_face)
-
-        thermo_params.thermal_conductivity[2:end] .= thermo_params.thermal_conductivity[begin]
-        thermo_params.density[2:end]              .= thermo_params.density[begin]
-        thermo_params.heat_capacity[2:end]        .= thermo_params.heat_capacity[begin]
-        thermo_params.reflectance_vis[2:end]      .= thermo_params.reflectance_vis[begin]
-        thermo_params.reflectance_ir[2:end]       .= thermo_params.reflectance_ir[begin]
-        thermo_params.emissivity[2:end]           .= thermo_params.emissivity[begin]
-    elseif length(thermo_params.thermal_conductivity) == n_face
-        # Do nothing
-    else
-        throw(ArgumentError("The length of the thermophysical parameters is invalid."))
-    end
-end
-
-
-"""
-    broadcast_thermo_params!(thermo_params::ThermoParams, shape::ShapeModel)
-
-Broadcast the thermophysical parameters to all faces if the values are uniform globally.
-
-# Arguments
-- `thermo_params` : Thermophysical parameters
-- `shape`         : Shape model
-"""
-broadcast_thermo_params!(thermo_params::ThermoParams, shape::ShapeModel) = broadcast_thermo_params!(thermo_params, length(shape.faces))
-
 
 """
     struct SingleAsteroidThermoPhysicalState <: AbstractAsteroidThermoPhysicalState

--- a/test/TPM_Didymos/TPM_Didymos.jl
+++ b/test/TPM_Didymos/TPM_Didymos.jl
@@ -96,26 +96,25 @@ See https://github.com/Astroshaper/Astroshaper-examples/tree/main/TPM_Didymos fo
     ρ  = 2170.0  # Density [kg/m³]
     Cₚ = 600.0   # Heat capacity [J/kg/K]
 
-    R_vis = 0.059  # Reflectance in visible light [-]
-    R_ir  = 0.0    # Reflectance in thermal infrared [-]
-    ε     = 0.9    # Emissivity [-]
-
-    z_max = 0.6   # Depth of the lower boundary of a heat conduction equation [m]
-    n_depth = 41  # Number of depth steps
-    Δz = z_max / (n_depth - 1)  # Depth step width [m]
-
-    thermo_params1 = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
-    thermo_params2 = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
+    thermo_params = ThermoParams(
+        conductivity    = k,     # Thermal conductivity [W/m/K]
+        density         = ρ,     # Density [kg/m³]
+        heat_capacity   = Cₚ,    # Heat capacity [J/kg/K]
+        reflectance_vis = 0.059, # Reflectance in visible light [-]
+        reflectance_ir  = 0.0,   # Reflectance in thermal infrared [-]
+        emissivity      = 0.9,   # Emissivity [-]
+    )
+    grid_params = GridParams(; z_max=0.6, n_depth=41)
 
     ## --- Setting of TPM ---
-    prob1 = SingleAsteroidThermoPhysicalProblem(shape1, thermo_params1;
+    prob1 = SingleAsteroidThermoPhysicalProblem(shape1, thermo_params, grid_params;
         with_self_shadowing      = true,
         with_self_heating        = true,
         upper_boundary_condition = RadiationBoundaryCondition(),
         lower_boundary_condition = InsulationBoundaryCondition(),
     )
 
-    prob2 = SingleAsteroidThermoPhysicalProblem(shape2, thermo_params2;
+    prob2 = SingleAsteroidThermoPhysicalProblem(shape2, thermo_params, grid_params;
         with_self_shadowing      = true,
         with_self_heating        = true,
         upper_boundary_condition = RadiationBoundaryCondition(),

--- a/test/TPM_Ryugu/TPM_Ryugu.jl
+++ b/test/TPM_Ryugu/TPM_Ryugu.jl
@@ -84,18 +84,18 @@ See https://github.com/Astroshaper/Astroshaper-examples/tree/main/TPM_Ryugu for 
     l = thermal_skin_depth(P, k, ρ, Cₚ)  # Thermal skin depth [m]
     Γ = thermal_inertia(k, ρ, Cₚ)        # Thermal inertia [tiu]
 
-    R_vis = 0.04  # Reflectance in visible light [-]
-    R_ir  = 0.0   # Reflectance in thermal infrared [-]
-    ε     = 1.0   # Emissivity [-]
-
-    z_max = 0.6   # Depth of the lower boundary of a heat conduction equation [m]
-    n_depth = 61  # Number of depth steps
-    Δz = z_max / (n_depth - 1)  # Depth step width [m]
-
-    thermo_params = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
+    thermo_params = ThermoParams(
+        conductivity    = k,     # Thermal conductivity [W/m/K]
+        density         = ρ,     # Density [kg/m³]
+        heat_capacity   = Cₚ,    # Heat capacity [J/kg/K]
+        reflectance_vis = 0.04,  # Reflectance in visible light [-]
+        reflectance_ir  = 0.0,   # Reflectance in thermal infrared [-]
+        emissivity      = 1.0,   # Emissivity [-]
+    )
+    grid_params = GridParams(; z_max=0.6, n_depth=61)
 
     ## --- Setting of TPM ---
-    problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
+    problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params;
         with_self_shadowing      = true,
         with_self_heating        = true,
         upper_boundary_condition = RadiationBoundaryCondition(),

--- a/test/TPM_non-uniform_thermoparams/TPM_non-uniform_thermoparams.jl
+++ b/test/TPM_non-uniform_thermoparams/TPM_non-uniform_thermoparams.jl
@@ -90,22 +90,18 @@ Based on TPM_Ryugu test but with varying thermophysical properties.
         - Emissivity           : ε   = 0.9  [-]
     """
 
-    k  = [r[3] > 0 ? 0.1 : 0.3  for r in shape.face_centers]  # Thermal conductivity [W/m/K]
-    ρ  = fill(1270.0, n_face)  # Density [kg/m³]
-    Cₚ = fill(600.0, n_face)   # Heat capacity [J/kg/K]
-
-    R_vis = [r[3] > 0 ? 0.04 : 0.1 for r in shape.face_centers]  # Reflectance in visible light [-]
-    R_ir  = [r[3] > 0 ? 0.0 : 0.0  for r in shape.face_centers]  # Reflectance in thermal infrared [-]
-    ε     = fill(1.0, n_face)   # Emissivity [-]
-
-    z_max = 0.6   # Depth of the lower boundary of a heat conduction equation [m]
-    n_depth = 41  # Number of depth steps
-    Δz = z_max / (n_depth - 1)  # Depth step width [m]
-
-    thermo_params = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
+    thermo_params = ThermoParams(
+        conductivity    = [r[3] > 0 ? 0.1  : 0.3  for r in shape.face_centers],  # non-uniform [W/m/K]
+        density         = 1270.0,                                                # uniform [kg/m³]
+        heat_capacity   = 600.0,                                                 # uniform [J/kg/K]
+        reflectance_vis = [r[3] > 0 ? 0.04 : 0.1  for r in shape.face_centers],  # non-uniform [-]
+        reflectance_ir  = 0.0,                                                   # uniform [-]
+        emissivity      = 1.0,                                                   # uniform [-]
+    )
+    grid_params = GridParams(; z_max=0.6, n_depth=41)
 
     ## --- Setting of TPM ---
-    problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
+    problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params;
         with_self_shadowing      = true,
         with_self_heating        = true,
         upper_boundary_condition = RadiationBoundaryCondition(),

--- a/test/TPM_zero-conductivity/TPM_zero-conductivity.jl
+++ b/test/TPM_zero-conductivity/TPM_zero-conductivity.jl
@@ -40,22 +40,18 @@ This test validates:
     n_face = length(shape.faces)  # Number of faces
 
     ## --- Thermal properties: zero-conductivity case ---
-    k  = 0.0     # Thermal conductivity [W/m/K]
-    ρ  = 1270.0  # Density [kg/m³]
-    Cₚ = 600.0   # Heat capacity [J/kg/K]
-
-    R_vis = 0.1  # Reflectance in visible light [-]
-    R_ir  = 0.0  # Reflectance in thermal infrared [-]
-    ε     = 1.0  # Emissivity [-]
-
-    z_max = 0.6   # Depth of the lower boundary of a heat conduction equation [m]
-    n_depth = 41  # Number of depth steps
-    Δz = z_max / (n_depth - 1)  # Depth step width [m]
-
-    thermo_params = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
+    thermo_params = ThermoParams(
+        conductivity    = 0.0,    # Thermal conductivity [W/m/K]
+        density         = 1270.0, # Density [kg/m³]
+        heat_capacity   = 600.0,  # Heat capacity [J/kg/K]
+        reflectance_vis = 0.1,    # Reflectance in visible light [-]
+        reflectance_ir  = 0.0,    # Reflectance in thermal infrared [-]
+        emissivity      = 1.0,    # Emissivity [-]
+    )
+    grid_params = GridParams(; z_max=0.6, n_depth=41)
 
     ## --- Setting of TPM ---
-    problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
+    problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params;
         with_self_shadowing      = true,
         with_self_heating        = false,
         upper_boundary_condition = RadiationBoundaryCondition(),

--- a/test/heat_conduction_1D.jl
+++ b/test/heat_conduction_1D.jl
@@ -37,15 +37,15 @@ Tests for 1D heat conduction solvers:
 
     z_max   = 1.0  # Depth of the lower boundary of a heat conduction equation [m]
     n_depth = 101  # Number of depth steps
-    Δz = z_max / (n_depth - 1)  # Depth step width [m]
 
-    thermo_params = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
+    thermo_params = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε)
+    grid_params   = GridParams(; z_max, n_depth)
 
     ## --- Build states with different solvers ---
     BC_UPPER = IsothermalBoundaryCondition(0)
     BC_LOWER = IsothermalBoundaryCondition(0)
 
-    problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
+    problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params;
         with_self_shadowing      = false,
         with_self_heating        = false,
         upper_boundary_condition = BC_UPPER,
@@ -58,7 +58,7 @@ Tests for 1D heat conduction solvers:
 
     ## --- Initial temperature ---
     T₀(x) = x < 0.5 ? 2x : 2(1 - x)
-    xs = [thermo_params.Δz * (i-1) for i in 1:thermo_params.n_depth]
+    xs = [grid_params.Δz * (i-1) for i in 1:grid_params.n_depth]
     Ts = [T₀(x) for x in xs]
 
     state_EE.temperature .= Ts

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,7 @@ include("TPM_zero-conductivity/TPM_zero-conductivity.jl")
 include("TPM_Didymos/TPM_Didymos.jl")
 
 include("thermal_radiation.jl")
+include("test_thermo_grid_params.jl")
 include("heat_conduction_1D.jl")
 include("test_boundary_conditions.jl")
 include("test_ephem_types.jl")

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -32,18 +32,18 @@ Validates both upper and lower boundary implementations.
     R_vis = 0.0                 # Reflectance in visible light [-]
     R_ir  = 0.0                 # Reflectance in thermal infrared [-]
     ε     = 1.0                 # Emissivity [-]
-    z_max = 1.0                 # Depth of the lower boundary of a heat conduction equation [m]
-    n_depth = 21                # Number of depth steps
-    Δz = z_max / (n_depth - 1)  # Depth step width [m]
+    z_max   = 1.0  # Depth of the lower boundary of a heat conduction equation [m]
+    n_depth = 21   # Number of depth steps
 
-    thermo_params = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
+    thermo_params = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε)
+    grid_params   = GridParams(; z_max, n_depth)
 
     @testset "Isothermal BC with non-zero temperatures" begin
         # Test with T_upper = 100, T_lower = 50
         BC_UPPER = IsothermalBoundaryCondition(100.0)
         BC_LOWER = IsothermalBoundaryCondition(50.0)
 
-        problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
+        problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params;
             with_self_shadowing      = false,
             with_self_heating        = false,
             upper_boundary_condition = BC_UPPER,
@@ -73,7 +73,7 @@ Validates both upper and lower boundary implementations.
         BC_UPPER = IsothermalBoundaryCondition(100.0)
         BC_LOWER = InsulationBoundaryCondition()
 
-        problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
+        problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params;
             with_self_shadowing      = false,
             with_self_heating        = false,
             upper_boundary_condition = BC_UPPER,

--- a/test/test_problem_api.jl
+++ b/test/test_problem_api.jl
@@ -92,6 +92,16 @@ Unit tests for the Problem-Solver API introduced in v0.2.0:
         @test state.temperature ≈ T_matrix
     end
 
+    @testset "_expand_thermo_params — wrong vector length" begin
+        # icosahedron has 20 faces; a ThermoParams with 3 entries is neither 1 nor n_face
+        tp_wrong = ThermoParams([0.1, 0.2, 0.3], [1000.0, 1000.0, 1000.0], [700.0, 700.0, 700.0],
+                                [0.1, 0.1, 0.1], [0.0, 0.0, 0.0], [0.9, 0.9, 0.9])
+        @test_throws ArgumentError SingleAsteroidThermoPhysicalProblem(shape2, tp_wrong, grid_params2;
+            with_self_shadowing = false,
+            with_self_heating   = false,
+        )
+    end
+
     @testset "init_temperature! binary per-body" begin
         prob = BinaryAsteroidThermoPhysicalProblem(
             (shape1, shape2),

--- a/test/test_problem_api.jl
+++ b/test/test_problem_api.jl
@@ -18,8 +18,25 @@ Unit tests for the Problem-Solver API introduced in v0.2.0:
 
     shape1 = load_shape_obj(joinpath(@__DIR__, "shape", "single_face.obj"))
     shape2 = load_shape_obj(joinpath(@__DIR__, "shape", "icosahedron.obj"))
-    thermo_params1 = ThermoParams(0.1, 1000.0, 700.0, 0.1, 0.0, 0.9, 0.1, 0.01, 10)
-    thermo_params2 = ThermoParams(0.2, 1500.0, 700.0, 0.2, 0.0, 0.9, 0.1, 0.01, 10)
+
+    thermo_params1 = ThermoParams(
+        conductivity    = 0.1,
+        density         = 1000.0,
+        heat_capacity   = 700.0,
+        reflectance_vis = 0.1,
+        reflectance_ir  = 0.0,
+        emissivity      = 0.9,
+    )
+    thermo_params2 = ThermoParams(
+        conductivity    = 0.2,
+        density         = 1500.0,
+        heat_capacity   = 700.0,
+        reflectance_vis = 0.2,
+        reflectance_ir  = 0.0,
+        emissivity      = 0.9,
+    )
+    grid_params1 = GridParams(; z_max=0.1, n_depth=10)
+    grid_params2 = GridParams(; z_max=0.1, n_depth=10)
 
     @testset "subsolar_temperature" begin
         au2m = AsteroidThermoPhysicalModels.au2m
@@ -37,7 +54,8 @@ Unit tests for the Problem-Solver API introduced in v0.2.0:
     @testset "BinaryAsteroidThermoPhysicalProblem convenience constructor" begin
         problem = BinaryAsteroidThermoPhysicalProblem(
             (shape1, shape2),
-            (thermo_params1, thermo_params2);
+            (thermo_params1, thermo_params2),
+            (grid_params1, grid_params2);
             with_self_shadowing   = false,
             with_self_heating     = false,
             with_mutual_shadowing = false,
@@ -53,20 +71,20 @@ Unit tests for the Problem-Solver API introduced in v0.2.0:
         @test problem.primary.with_self_heating   == problem.secondary.with_self_heating   == false
         @test problem.with_mutual_shadowing == false
         @test problem.with_mutual_heating   == false
-        
+
         # Each body gets its own parameters
-        @test problem.primary.thermo_params.thermal_conductivity[begin]   ≈ 0.1
-        @test problem.secondary.thermo_params.thermal_conductivity[begin] ≈ 0.2
+        @test problem.primary.thermo_params.conductivity[begin]   ≈ 0.1
+        @test problem.secondary.thermo_params.conductivity[begin] ≈ 0.2
     end
 
     @testset "init_temperature! with AbstractMatrix" begin
-        problem = SingleAsteroidThermoPhysicalProblem(shape1, thermo_params1;
+        problem = SingleAsteroidThermoPhysicalProblem(shape1, thermo_params1, grid_params1;
             with_self_shadowing = false,
             with_self_heating   = false,
         )
         state = AsteroidThermoPhysicalModels._build_single_state(problem, CrankNicolson())
 
-        n_depth  = thermo_params1.n_depth
+        n_depth  = grid_params1.n_depth
         n_face   = length(shape1.faces)
         T_matrix = fill(350.0, n_depth, n_face)
         AsteroidThermoPhysicalModels.init_temperature!(state, T_matrix)
@@ -77,7 +95,8 @@ Unit tests for the Problem-Solver API introduced in v0.2.0:
     @testset "init_temperature! binary per-body" begin
         prob = BinaryAsteroidThermoPhysicalProblem(
             (shape1, shape2),
-            (thermo_params1, thermo_params2);
+            (thermo_params1, thermo_params2),
+            (grid_params1, grid_params2);
             with_self_shadowing   = false,
             with_self_heating     = false,
             with_mutual_shadowing = false,

--- a/test/test_thermo_grid_params.jl
+++ b/test/test_thermo_grid_params.jl
@@ -1,0 +1,141 @@
+#=
+test_thermo_grid_params.jl
+
+Unit tests for ThermoParams and GridParams types:
+- Construction from scalars, vectors, and mixed arguments
+- Keyword argument constructors
+- Automatic broadcast of scalar arguments to vector length
+- Validation of vector length consistency
+=#
+
+@testset "ThermoParams" begin
+    msg = """
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    |               Test: ThermoParams                      |
+    ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+    """
+    println(msg)
+
+    k     = 0.1
+    ρ     = 1500.0
+    Cₚ    = 800.0
+    R_vis = 0.05
+    R_ir  = 0.0
+    ε     = 0.9
+
+    @testset "Scalar constructor — uniform surface" begin
+        tp = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε)
+
+        @test tp isa ThermoParams
+        @test length(tp.conductivity)    == 1
+        @test tp.conductivity[1]    ≈ k
+        @test tp.density[1]         ≈ ρ
+        @test tp.heat_capacity[1]   ≈ Cₚ
+        @test tp.reflectance_vis[1] ≈ R_vis
+        @test tp.reflectance_ir[1]  ≈ R_ir
+        @test tp.emissivity[1]      ≈ ε
+    end
+
+    @testset "Keyword constructor — uniform surface" begin
+        tp = ThermoParams(
+            conductivity    = k,
+            density         = ρ,
+            heat_capacity   = Cₚ,
+            reflectance_vis = R_vis,
+            reflectance_ir  = R_ir,
+            emissivity      = ε,
+        )
+
+        @test tp isa ThermoParams
+        @test tp.conductivity[1]    ≈ k
+        @test tp.reflectance_vis[1] ≈ R_vis
+        @test tp.emissivity[1]      ≈ ε
+    end
+
+    @testset "Vector constructor — non-uniform surface" begin
+        n = 5
+        k_vec     = fill(k, n)
+        R_vis_vec = [0.04, 0.05, 0.06, 0.07, 0.08]
+        tp = ThermoParams(k_vec, fill(ρ, n), fill(Cₚ, n), R_vis_vec, fill(R_ir, n), fill(ε, n))
+
+        @test length(tp.conductivity)    == n
+        @test length(tp.reflectance_vis) == n
+        @test tp.reflectance_vis ≈ R_vis_vec
+    end
+
+    @testset "Mixed scalar/vector constructor" begin
+        n = 4
+        k_vec = [0.1, 0.2, 0.3, 0.4]
+        tp = ThermoParams(k_vec, ρ, Cₚ, R_vis, R_ir, ε)
+
+        @test length(tp.conductivity)  == n
+        @test length(tp.density)       == n
+        @test length(tp.emissivity)    == n
+        @test tp.conductivity         ≈ k_vec
+        @test all(tp.density         .≈ ρ)
+        @test all(tp.heat_capacity   .≈ Cₚ)
+        @test all(tp.emissivity      .≈ ε)
+    end
+
+    @testset "Keyword constructor — mixed scalar/vector" begin
+        n = 3
+        k_vec = [0.1, 0.2, 0.3]
+        tp = ThermoParams(
+            conductivity    = k_vec,
+            density         = ρ,
+            heat_capacity   = Cₚ,
+            reflectance_vis = R_vis,
+            reflectance_ir  = R_ir,
+            emissivity      = ε,
+        )
+
+        @test length(tp.conductivity) == n
+        @test all(tp.density .≈ ρ)
+    end
+
+    @testset "Validation — mismatched vector lengths" begin
+        k_vec = [0.1, 0.2, 0.3]
+        ρ_vec = [1500.0, 1600.0]  # different length
+        @test_throws ArgumentError ThermoParams(k_vec, ρ_vec, Cₚ, R_vis, R_ir, ε)
+    end
+end
+
+
+@testset "GridParams" begin
+    msg = """
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    |               Test: GridParams                        |
+    ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+    """
+    println(msg)
+
+    z_max   = 0.6
+    n_depth = 61
+
+    @testset "Keyword constructor — auto Δz" begin
+        gp = GridParams(; z_max, n_depth)
+
+        @test gp isa GridParams
+        @test gp.z_max   ≈ z_max
+        @test gp.n_depth == n_depth
+        @test gp.Δz      ≈ z_max / (n_depth - 1)
+    end
+
+    @testset "Positional constructor — explicit Δz" begin
+        Δz = z_max / (n_depth - 1)
+        gp = GridParams(z_max, n_depth, Δz)
+
+        @test gp.z_max   ≈ z_max
+        @test gp.n_depth == n_depth
+        @test gp.Δz      ≈ Δz
+    end
+
+    @testset "Both constructors are consistent" begin
+        gp_kw  = GridParams(; z_max, n_depth)
+        gp_pos = GridParams(z_max, n_depth, z_max / (n_depth - 1))
+
+        @test gp_kw.z_max   ≈ gp_pos.z_max
+        @test gp_kw.n_depth == gp_pos.n_depth
+        @test gp_kw.Δz      ≈ gp_pos.Δz
+    end
+end

--- a/test/test_tpm_with_force.jl
+++ b/test/test_tpm_with_force.jl
@@ -33,7 +33,15 @@ Covers: _alloc_solution (with forces/torques), record_timestep! (with R),
     r_sun = [inv(RotZ(2π * et / P)) * SVector(au2m, 0.0, 0.0) for et in et_range]
 
     path_obj      = joinpath("shape", "icosahedron.obj")
-    thermo_params = ThermoParams(0.1, 1000.0, 600.0, 0.1, 0.0, 0.9, 0.1, 0.01, 5)
+    thermo_params = ThermoParams(
+        conductivity    = 0.1,
+        density         = 1000.0,
+        heat_capacity   = 600.0,
+        reflectance_vis = 0.1,
+        reflectance_ir  = 0.0,
+        emissivity      = 0.9,
+    )
+    grid_params = GridParams(; z_max=0.1, n_depth=5)
     output_times        = times[end-n_step_cycle:end]
     subsurface_face_ids = [1]
 
@@ -44,7 +52,7 @@ Covers: _alloc_solution (with forces/torques), record_timestep! (with R),
         @test ephem isa SingleAsteroidEphemerides{Vector{SMatrix{3,3,Float64,9}}}
 
         shape   = load_shape_obj(path_obj; scale=1000, with_face_visibility=false, with_bvh=false)
-        problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
+        problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params;
             with_self_shadowing = false,
             with_self_heating   = false,
         )
@@ -85,7 +93,7 @@ Covers: _alloc_solution (with forces/torques), record_timestep! (with R),
         ephem_no_rot = SingleAsteroidEphemerides(times, r_sun)
 
         shape   = load_shape_obj(path_obj; scale=1000, with_face_visibility=false, with_bvh=false)
-        problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
+        problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params;
             with_self_shadowing = false,
             with_self_heating   = false,
         )
@@ -130,7 +138,8 @@ Covers: _alloc_solution (with forces/torques), record_timestep! (with R),
         shape2  = load_shape_obj(path_obj; scale=500,  with_face_visibility=false, with_bvh=false)
         problem = BinaryAsteroidThermoPhysicalProblem(
             (shape1, shape2),
-            (thermo_params, thermo_params);
+            thermo_params,
+            grid_params;
             with_self_shadowing   = false,
             with_self_heating     = false,
             with_mutual_shadowing = false,

--- a/test/thermal_radiation.jl
+++ b/test/thermal_radiation.jl
@@ -67,18 +67,18 @@ This test validates:
     l = thermal_skin_depth(P, k, ρ, Cₚ)
     Γ = thermal_inertia(k, ρ, Cₚ)
 
-    R_vis = 0.04  # Reflectance in visible light [-]
-    R_ir  = 0.0   # Reflectance in thermal infrared [-]
-    ε     = 1.0   # Emissivity [-]
-
-    z_max = 0.6   # Depth of the lower boundary of a heat conduction equation [m]
-    n_depth = 41  # Number of depth steps
-    Δz = z_max / (n_depth - 1)  # Depth step width [m]
-
-    thermo_params = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
+    thermo_params = ThermoParams(
+        conductivity    = k,     # Thermal conductivity [W/m/K]
+        density         = ρ,     # Density [kg/m³]
+        heat_capacity   = Cₚ,    # Heat capacity [J/kg/K]
+        reflectance_vis = 0.04,  # Reflectance in visible light [-]
+        reflectance_ir  = 0.0,   # Reflectance in thermal infrared [-]
+        emissivity      = 1.0,   # Emissivity [-]
+    )
+    grid_params = GridParams(; z_max=0.6, n_depth=41)
 
     ## --- Setting of TPM ---
-    problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
+    problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params;
         with_self_shadowing      = true,
         with_self_heating        = true,
         upper_boundary_condition = RadiationBoundaryCondition(),


### PR DESCRIPTION
## Summary

- Extract `GridParams` from the monolithic `ThermoParams` so that thermophysical material properties and numerical grid configuration are held in separate, focused types
- Add keyword-argument constructors for both types and a mixed scalar/vector constructor for `ThermoParams`
- Update all problem constructors, solvers, and tests to the new API

## Changes

### New type: `GridParams`

```julia
# Keyword constructor (recommended) — Δz is auto-computed
grid_params = GridParams(; z_max=0.6, n_depth=61)

# Positional constructor — explicit Δz (advanced use)
grid_params = GridParams(z_max, n_depth, Δz)
```

Fields: `z_max`, `n_depth`, `Δz` (primary params first, derived last).

### Redesigned `ThermoParams`

```julia
# Keyword constructor (recommended)
thermo_params = ThermoParams(
    conductivity    = 0.1,
    density         = 1270.0,
    heat_capacity   = 600.0,
    reflectance_vis = 0.04,
    reflectance_ir  = 0.0,
    emissivity      = 1.0,
)

# Mixed scalar/vector — scalars are auto-broadcast to match vector length
thermo_params = ThermoParams(
    conductivity    = [0.1, 0.3, ...],  # per-face vector
    density         = 1270.0,           # scalar → broadcast
    heat_capacity   = 600.0,
    reflectance_vis = [0.04, 0.1, ...],
    reflectance_ir  = 0.0,
    emissivity      = 1.0,
)
```

### Updated problem constructors

```julia
# Single asteroid
problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params; ...)

# Binary asteroid — per-body or shared params
problem = BinaryAsteroidThermoPhysicalProblem(
    (shape1, shape2),
    (thermo_params1, thermo_params2),
    (grid_params1, grid_params2);
    ...
)
# shared:
problem = BinaryAsteroidThermoPhysicalProblem(
    (shape1, shape2), thermo_params, grid_params; ...
)
```

## Breaking Changes

| Before (v0.2.x) | After (v0.3.0) |
|---|---|
| `ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)` | `ThermoParams(…) + GridParams(; z_max, n_depth)` |
| `thermo_params.thermal_conductivity` | `thermo_params.conductivity` |
| `thermo_params.n_depth` / `.Δz` | `grid_params.n_depth` / `.Δz` |
| `Problem(shape, thermo_params; …)` | `Problem(shape, thermo_params, grid_params; …)` |
| `broadcast_thermo_params!` | removed (expansion happens at construction time) |

## Test plan

- [x] Unit tests for `ThermoParams`: scalar, keyword, vector, mixed scalar/vector, keyword mixed, mismatched-length validation (`test/test_thermo_grid_params.jl`)
- [x] Unit tests for `GridParams`: keyword auto-Δz, positional explicit Δz, constructor consistency
- [x] All existing integration tests updated and passing (`Pkg.test()` — 189 tests, 0 failures)
- [x] Migration guide added to `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)