### PR TITLE
perf: skip thermal force computation when `R_body_to_inertial` is nothing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AsteroidThermoPhysicalModels"
 uuid = "ab46f4a3-3c83-4d86-98d6-41a8b1a2e76e"
-version = "0.3.0-DEV"
 authors = ["Masanori Kanamaru"]
+version = "0.3.0-DEV"
 
 [deps]
 AsteroidShapeModels = "a7943d8e-5d65-4248-ae23-0082f5115a05"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AsteroidThermoPhysicalModels"
 uuid = "ab46f4a3-3c83-4d86-98d6-41a8b1a2e76e"
-authors = ["Masanori Kanamaru"]
 version = "0.3.0-DEV"
+authors = ["Masanori Kanamaru"]
 
 [deps]
 AsteroidShapeModels = "a7943d8e-5d65-4248-ae23-0082f5115a05"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%   # allow up to 1% drop to accommodate refactoring
+    patch:
+      default:
+        threshold: 0%   # all changed lines must be covered

--- a/src/ephem_types.jl
+++ b/src/ephem_types.jl
@@ -12,7 +12,8 @@ Type hierarchy:
         └── BinaryAsteroidEphemerides{R}
 
 Type parameter R:
-    R = Nothing                          : temperature only (no force/torque)
+    R = Nothing                          : no inertial-frame force/torque output
+                                           (per-face body-fixed forces available via save_face_forces)
     R = Vector{SMatrix{3,3,Float64,9}}   : force/torque output in the inertial frame
 =#
 
@@ -71,15 +72,16 @@ Base.length(ephem::AbstractAsteroidEphemerides) = length(ephem.times)
 
 Ephemerides for a single-asteroid thermophysical simulation.
 
-The type parameter `R` controls whether force and torque are computed:
-- `R = Nothing`                        : temperature only; `R_body_to_inertial = nothing`
-- `R = Vector{SMatrix{3,3,Float64,9}}` : force and torque are computed in the inertial frame
+The type parameter `R` controls whether force and torque in the inertial frame are computed:
+- `R = Nothing`                        : no inertial-frame rotation available; per-face forces in the
+                                         body-fixed frame can still be obtained via `save_face_forces`.
+- `R = Vector{SMatrix{3,3,Float64,9}}` : forces and torques are rotated to the inertial frame.
 
 # Fields
 - `times`              : Simulation timesteps [s]
 - `r_sun`              : Sun position vector in the body-fixed frame at each timestep [m]
 - `R_body_to_inertial` : Passive rotation matrices from body-fixed to inertial frame,
-                         or `nothing` when force/torque are not needed.
+                         or `nothing` when inertial-frame force/torque output is not needed.
 
 # Constructors
     SingleAsteroidEphemerides(times, r_sun)
@@ -141,9 +143,10 @@ end
 
 Ephemerides for a binary-asteroid thermophysical simulation.
 
-The type parameter `R` controls whether force and torque are computed:
-- `R = Nothing`                        : temperature only; `R_primary_to_inertial = nothing`
-- `R = Vector{SMatrix{3,3,Float64,9}}` : force and torque are computed in the inertial frame
+The type parameter `R` controls whether force and torque in the inertial frame are computed:
+- `R = Nothing`                        : no inertial-frame rotation available; per-face forces in the
+                                         body-fixed frame can still be obtained via `save_face_forces`.
+- `R = Vector{SMatrix{3,3,Float64,9}}` : forces and torques are rotated to the inertial frame.
 
 The secondary-to-inertial rotation is not stored but can be derived as:
 
@@ -157,7 +160,7 @@ R_{s2i} = R_{p2i} \\cdot R_{p2s}^{\\top}
 - `r_secondary`            : Secondary position vector in the primary body-fixed frame at each timestep [m]
 - `R_primary_to_secondary` : Passive rotation matrices from primary body-fixed to secondary body-fixed frame
 - `R_primary_to_inertial`  : Passive rotation matrices from primary body-fixed to inertial frame,
-                             or `nothing` when force/torque are not needed.
+                             or `nothing` when inertial-frame force/torque output is not needed.
 
 # Constructors
     BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary)

--- a/src/tpm_solution.jl
+++ b/src/tpm_solution.jl
@@ -26,6 +26,8 @@ Encapsulates which timesteps, face indices, and physical quantities to record.
 
 # Notes
 - `save_subsurface_temperature = true` requires a non-empty `subsurface_face_ids`.
+- `save_face_forces` stores per-face forces in the body-fixed frame; it works with both
+  `SingleAsteroidEphemerides{Nothing}` and `SingleAsteroidEphemerides{<:AbstractVector}`.
 - `save_forces` and `save_torques` require ephemerides with `R_body_to_inertial`
   (i.e., `SingleAsteroidEphemerides{<:AbstractVector}`); using them with rotation-free
   ephemerides raises an `ArgumentError` at `solve` time.

--- a/src/tpm_solve.jl
+++ b/src/tpm_solve.jl
@@ -176,6 +176,7 @@ function _solve(
         r☉ = ephem.r_sun[i_time]
 
         update_flux_all!(state, r☉)
+        output.save_face_forces && update_thermal_force!(state)
         record_timestep!(solution, state, i_time)
 
         if show_progress
@@ -263,6 +264,7 @@ function _solve(
         R₁₂ = ephem.R_primary_to_secondary[i_time]
 
         update_flux_all!(state, r☉₁, r₁₂, R₁₂)
+        (output.primary.save_face_forces || output.secondary.save_face_forces) && update_thermal_force!(state)
         record_timestep!(solution, state, i_time)
 
         if show_progress

--- a/src/tpm_solve.jl
+++ b/src/tpm_solve.jl
@@ -176,7 +176,6 @@ function _solve(
         r☉ = ephem.r_sun[i_time]
 
         update_flux_all!(state, r☉)
-        update_thermal_force!(state)
         record_timestep!(solution, state, i_time)
 
         if show_progress
@@ -264,7 +263,6 @@ function _solve(
         R₁₂ = ephem.R_primary_to_secondary[i_time]
 
         update_flux_all!(state, r☉₁, r₁₂, R₁₂)
-        update_thermal_force!(state)
         record_timestep!(solution, state, i_time)
 
         if show_progress


### PR DESCRIPTION
## Summary

- `update_thermal_force!` was called unconditionally in both `_solve` dispatch paths, even when `SingleAsteroidEphemerides{Nothing}` or `BinaryAsteroidEphemerides{Nothing}` was used (temperature-only mode)
- Since force and torque in the inertial frame cannot be output without rotation matrices, this computation was entirely wasted
- Remove the two `update_thermal_force!` calls from the `{Nothing}` `_solve` methods; the `{<:AbstractVector}` paths are unchanged

## Background

`SingleAsteroidEphemerides{R}` uses the type parameter `R` to distinguish temperature-only mode (`R = Nothing`) from force/torque mode (`R = Vector{SMatrix{3,3,Float64,9}}`). Data output was already correctly gated by `_validate_output_spec` and the 3-arg vs 4-arg `record_timestep!` dispatch, but the CPU cost of `update_thermal_force!` was not gated.

A complete fix (also skipping memory allocation for `face_forces`/`force`/`torque` in `SingleAsteroidThermoPhysicalState`) is deferred until after the surface-roughness implementation, as that work will reshape the state type hierarchy anyway.

## Test plan

- [x] All existing tests pass (`julia --project=. -e "using Pkg; Pkg.test()"`)