### PR TITLE
refactor: rename type parameters for consistency

### DIFF
--- a/src/tpm_problem.jl
+++ b/src/tpm_problem.jl
@@ -46,17 +46,17 @@ solution = solve(problem, CrankNicolson(); ephem = ephem, initial_temperature = 
 ```
 """
 struct SingleAsteroidThermoPhysicalProblem{
-    Sh <: AbstractShapeModel,
-    BU <: AbstractBoundaryCondition,
-    BL <: AbstractBoundaryCondition,
+    Sh  <: AbstractShapeModel,
+    UBC <: AbstractBoundaryCondition,
+    LBC <: AbstractBoundaryCondition,
 } <: AbstractThermoPhysicalProblem
     shape                    ::Sh
     thermo_params            ::ThermoParams
     grid_params              ::GridParams
     with_self_shadowing      ::Bool
     with_self_heating        ::Bool
-    upper_boundary_condition ::BU
-    lower_boundary_condition ::BL
+    upper_boundary_condition ::UBC
+    lower_boundary_condition ::LBC
 end
 
 
@@ -152,11 +152,11 @@ solution = solve(problem, CrankNicolson(); ephem = ephem, T₀ = 200.0)
 ```
 """
 struct BinaryAsteroidThermoPhysicalProblem{
-    P1 <: SingleAsteroidThermoPhysicalProblem,
-    P2 <: SingleAsteroidThermoPhysicalProblem,
+    Pr1 <: SingleAsteroidThermoPhysicalProblem,
+    Pr2 <: SingleAsteroidThermoPhysicalProblem,
 } <: AbstractThermoPhysicalProblem
-    primary               ::P1
-    secondary             ::P2
+    primary               ::Pr1
+    secondary             ::Pr2
     with_mutual_shadowing ::Bool
     with_mutual_heating   ::Bool
 end

--- a/src/tpm_state.jl
+++ b/src/tpm_state.jl
@@ -11,7 +11,6 @@ Abstract type for asteroid thermophysical simulation state.
 abstract type AbstractAsteroidThermoPhysicalState end
 
 
-
 """
     struct SingleAsteroidThermoPhysicalState <: AbstractAsteroidThermoPhysicalState
 
@@ -34,10 +33,10 @@ accessed via the `problem` field to avoid duplication.
 """
 struct SingleAsteroidThermoPhysicalState{
     Pr <: SingleAsteroidThermoPhysicalProblem,
-    S  <: HeatConductionCache,
+    C  <: HeatConductionCache,
 } <: AbstractAsteroidThermoPhysicalState
     problem           ::Pr
-    solver_cache      ::S
+    solver_cache      ::C
     illuminated_faces ::Vector{Bool}
     flux_sun          ::Vector{Float64}
     flux_scat         ::Vector{Float64}
@@ -68,21 +67,21 @@ state.secondary.problem === state.problem.secondary
 Use `_build_binary_state` rather than constructing directly to guarantee consistency.
 """
 struct BinaryAsteroidThermoPhysicalState{
-    S1 <: SingleAsteroidThermoPhysicalState,
-    S2 <: SingleAsteroidThermoPhysicalState,
+    St1 <: SingleAsteroidThermoPhysicalState,
+    St2 <: SingleAsteroidThermoPhysicalState,
 } <: AbstractAsteroidThermoPhysicalState
     problem   ::BinaryAsteroidThermoPhysicalProblem
-    primary   ::S1
-    secondary ::S2
+    primary   ::St1
+    secondary ::St2
 
     function BinaryAsteroidThermoPhysicalState(
         problem   ::BinaryAsteroidThermoPhysicalProblem,
-        primary   ::S1,
-        secondary ::S2,
-    ) where {S1 <: SingleAsteroidThermoPhysicalState, S2 <: SingleAsteroidThermoPhysicalState}
+        primary   ::St1,
+        secondary ::St2,
+    ) where {St1 <: SingleAsteroidThermoPhysicalState, St2 <: SingleAsteroidThermoPhysicalState}
         primary.problem   === problem.primary   || error("primary.problem ≢ problem.primary: use _build_binary_state to construct")
         secondary.problem === problem.secondary || error("secondary.problem ≢ problem.secondary: use _build_binary_state to construct")
-        new{S1, S2}(problem, primary, secondary)
+        new{St1, St2}(problem, primary, secondary)
     end
 end
 

--- a/src/tpm_state.jl
+++ b/src/tpm_state.jl
@@ -32,11 +32,11 @@ accessed via the `problem` field to avoid duplication.
 - `torque`            : Net thermal recoil torque in body-fixed frame [N⋅m]
 """
 struct SingleAsteroidThermoPhysicalState{
-    Pr <: SingleAsteroidThermoPhysicalProblem,
-    C  <: HeatConductionCache,
+    Pr  <: SingleAsteroidThermoPhysicalProblem,
+    HCC <: HeatConductionCache,
 } <: AbstractAsteroidThermoPhysicalState
     problem           ::Pr
-    solver_cache      ::C
+    solver_cache      ::HCC
     illuminated_faces ::Vector{Bool}
     flux_sun          ::Vector{Float64}
     flux_scat         ::Vector{Float64}


### PR DESCRIPTION
## Summary

Adopt a package-wide type parameter naming convention across all struct definitions to improve readability and prepare for upcoming `HierarchicalSingleAsteroidThermoPhysicalState{Pr, HCC, St}`.

| Before | After | Meaning |
|---|---|---|
| `S` | `HCC` | Cache (`HeatConductionCache`) |
| `S1`, `S2` | `St1`, `St2` | State (`SingleAsteroidThermoPhysicalState`) |
| `BU`, `BL` | `UBC`, `LBC` | Upper/Lower Boundary Condition |
| `P1`, `P2` | `Pr1`, `Pr2` | Problem (`SingleAsteroidThermoPhysicalProblem`) |

The convention: `Sh` (Shape), `UBC`/`LBC` (Boundary Conditions), `Pr` (Problem), `HCC` (HeatConductionCache), `St` (State), with numeric suffixes for binary-system variants. All 2–3 character codes derive directly from the abstract type name (`HCC` ← `HeatConductionCache`, `UBC`/`LBC` ← `AbstractBoundaryCondition`).

## Test plan

- [x] All existing tests pass (`Pkg.test()`)
- [x] No runtime behavior changes (type parameters are internal to struct definitions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)