### PR TITLE
fix: add `mkpath` in `export_solution` for single-asteroid case

### DIFF
--- a/src/tpm_solution.jl
+++ b/src/tpm_solution.jl
@@ -514,6 +514,7 @@ end
     export_solution(dirpath, solution::SingleAsteroidThermoPhysicalSolution)
 
 Export simulation results to CSV files in `dirpath`.
+`dirpath` is created automatically if it does not exist.
 
 Files written depend on the `output` specification:
 - `diagnostics.csv`            : always (`absorbed_power`, `emitted_power` at all timesteps)
@@ -523,6 +524,7 @@ Files written depend on the `output` specification:
 - `thermal_net_forces.csv`     : when `output.save_forces = true` or `output.save_torques = true`
 """
 function export_solution(dirpath, solution::SingleAsteroidThermoPhysicalSolution)
+    mkpath(dirpath)
     _export_diagnostics(dirpath, solution)
     solution.output.save_surface_temperature    && _export_surface_temperature(dirpath, solution)
     solution.output.save_subsurface_temperature && _export_subsurface_temperature(dirpath, solution)
@@ -535,6 +537,7 @@ end
     export_solution(dirpath, solution::BinaryAsteroidThermoPhysicalSolution)
 
 Export results for both bodies to `dirpath/primary/` and `dirpath/secondary/`.
+All directories are created automatically if they do not exist.
 """
 function export_solution(dirpath, solution::BinaryAsteroidThermoPhysicalSolution)
     dirpath1 = joinpath(dirpath, "primary")

--- a/test/test_tpm_with_force.jl
+++ b/test/test_tpm_with_force.jl
@@ -176,4 +176,57 @@ Covers: _alloc_solution (with forces/torques), record_timestep! (with R),
             @test "torque_x" in names(df)
         end
     end
+
+    @testset "export_solution creates output directory — single asteroid" begin
+        shape = load_shape_obj(path_obj; scale=1000, with_face_visibility=false, with_bvh=false)
+        solution = solve(
+            SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params;
+                with_self_shadowing=false, with_self_heating=false),
+            ExplicitEuler();
+            ephem               = SingleAsteroidEphemerides(times, r_sun),
+            output              = SingleAsteroidOutputSpec(output_times, subsurface_face_ids),
+            initial_temperature = 200.0,
+            show_progress       = false,
+        )
+
+        dir = joinpath(mktempdir(), "nonexistent", "single")
+        @test !isdir(dir)
+        export_solution(dir, solution)
+        @test isdir(dir)
+        @test isfile(joinpath(dir, "diagnostics.csv"))
+    end
+
+    @testset "export_solution creates output directory — binary asteroid" begin
+        shape1 = load_shape_obj(path_obj; scale=1000, with_face_visibility=false, with_bvh=false)
+        shape2 = load_shape_obj(path_obj; scale=500,  with_face_visibility=false, with_bvh=false)
+
+        solution = solve(
+            BinaryAsteroidThermoPhysicalProblem(
+                (shape1, shape2), thermo_params, grid_params;
+                with_self_shadowing=false, with_self_heating=false,
+                with_mutual_shadowing=false, with_mutual_heating=false,
+            ),
+            ExplicitEuler();
+            ephem = BinaryAsteroidEphemerides(
+                times, r_sun,
+                [[1e4, 0.0, 0.0] for _ in times],
+                [Matrix{Float64}(I, 3, 3) for _ in times],
+            ),
+            output = BinaryAsteroidOutputSpec(
+                SingleAsteroidOutputSpec(output_times, subsurface_face_ids),
+                SingleAsteroidOutputSpec(output_times, subsurface_face_ids),
+            ),
+            initial_temperature_primary   = 200.0,
+            initial_temperature_secondary = 200.0,
+            show_progress                 = false,
+        )
+        
+        dir = joinpath(mktempdir(), "nonexistent", "binary")
+        @test !isdir(dir)
+        export_solution(dir, solution)
+        @test isdir(joinpath(dir, "primary"))
+        @test isdir(joinpath(dir, "secondary"))
+        @test isfile(joinpath(dir, "primary",   "diagnostics.csv"))
+        @test isfile(joinpath(dir, "secondary", "diagnostics.csv"))
+    end
 end


### PR DESCRIPTION
## Summary

- `export_solution` for `SingleAsteroidThermoPhysicalSolution` did not call `mkpath`, so it would error if the output directory did not exist.
- The `BinaryAsteroidThermoPhysicalSolution` overload already called `mkpath` for `primary/` and `secondary/` subdirectories — this fix makes the two methods consistent.
- Both docstrings now state that output directories are created automatically.

## Test plan

- [x] Two new testsets added to `test_tpm_with_force.jl`:
  - `"export_solution creates output directory — single asteroid"`: verifies that calling `export_solution` with a non-existent path creates the directory and writes `diagnostics.csv`
  - `"export_solution creates output directory — binary asteroid"`: same check for `primary/` and `secondary/` subdirectories

🤖 Generated with [Claude Code](https://claude.com/claude-code)